### PR TITLE
feat: add Nix flake devShell aligned with CI toolchain

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# Automatically activate the Nix devShell when entering this directory.
+# Requires direnv (https://direnv.net/) and nix-direnv.
+# Run `direnv allow` once after cloning.
+use flake

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,98 @@
+{
+  description = "A Nix-flake-based Rust development environment for rust-2026-template";
+
+  inputs = {
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
+    fenix = {
+      url = "https://flakehub.com/f/nix-community/fenix/0.1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    { self, ... }@inputs:
+    let
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forEachSupportedSystem =
+        f:
+        inputs.nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              overlays = [ inputs.self.overlays.default ];
+            };
+          }
+        );
+    in
+    {
+      overlays.default = final: prev: {
+        # Mirrors rust-toolchain.toml: stable channel with clippy, rustfmt, rust-src.
+        # Update the channel version here when rust-toolchain.toml is updated.
+        rustToolchain =
+          with inputs.fenix.packages.${prev.stdenv.hostPlatform.system};
+          combine (
+            with stable; [
+              clippy
+              rustc
+              cargo
+              rustfmt
+              rust-src
+            ]
+          );
+      };
+
+      devShells = forEachSupportedSystem (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              # Rust toolchain (matches rust-toolchain.toml)
+              rustToolchain
+              rust-analyzer
+
+              # Build essentials
+              openssl
+              pkg-config
+
+              # Cargo tools - mirrors CI pipeline jobs
+              cargo-binstall   # fast binary installs
+              cargo-deny       # supply chain / license checks (deny.toml)
+              cargo-nextest    # test runner (.config/nextest.toml)
+              cargo-audit      # security audit (CI security job)
+              cargo-watch      # local file-watch rebuilds
+
+              # Code quality
+              typos            # typo linter (CI quality gate)
+              just             # task runner (optional: add justfile)
+              tokei            # line count utility
+
+              # Uncomment for WASM targets:
+              # wasm-bindgen-cli
+              # rust-bindgen
+
+              # Uncomment for web UI (Leptos) projects:
+              # cargo-leptos
+              # leptosfmt
+
+              # Uncomment for desktop app (Tauri) projects:
+              # cargo-tauri
+
+              # Uncomment for database projects:
+              # sqlx-cli
+            ];
+
+            env = {
+              # Required by rust-analyzer and proc-macro expansion
+              RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+            };
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
## Summary

Adds a `flake.nix` and `.envrc` to provide a reproducible Nix-based development environment that mirrors the existing CI toolchain.

## Changes

### `flake.nix`
- Uses [fenix](https://github.com/nix-community/fenix) to provide the stable Rust toolchain, matching `rust-toolchain.toml` (clippy, rustc, cargo, rustfmt, rust-src)
- Includes all tools that correspond directly to CI pipeline jobs:
  - `cargo-deny` → `deny.toml` supply chain/license checks
  - `cargo-nextest` → `.config/nextest.toml` test runner
  - `cargo-audit` → security audit CI job
  - `cargo-watch`, `cargo-binstall`, `typos`, `just`, `tokei`
- Supports 4 platforms: `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`
- Sets `RUST_SRC_PATH` for rust-analyzer proc-macro expansion
- Opinionated/app-specific tools (Leptos, Tauri, sqlx, WASM) are kept as **opt-in commented entries**

### `.envrc`
- Enables automatic devShell activation via [direnv](https://direnv.net/) + [nix-direnv](https://github.com/nix-community/nix-direnv)
- Users run `direnv allow` once after cloning

## What was removed from the original flake proposal

| Removed | Reason |
|---|---|
| `cargo-leptos`, `leptosfmt` | Leptos-specific, not in template scope |
| `cargo-tauri` | Desktop app tooling, not in template scope |
| `wasm-bindgen-cli`, `rust-bindgen` | WASM opt-in (commented out in `rust-toolchain.toml`) |
| `sqlx-cli` | DB-specific, not in template scope |
| `rust-ui-cli` shellHook | Unknown/niche crate, unsafe silent install |
| `cargo-edit` | Not part of CI or quality gates |

## Usage

```bash
# With nix flakes enabled:
nix develop

# With direnv + nix-direnv (automatic on cd):
direnv allow
```
