### PR TITLE
🛡️ Sentinel: Implement DoS protection for config loading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Personal Identifiable Information (PII) leakage through email addresses in the codebase (Cargo.toml, READMEs, etc.).
 **Learning:** While the project had a `privacy-first` skill and policy, it was only a guideline for AI agents and lacked automated enforcement in the local development workflow or CI.
 **Prevention:** Added a Privacy Check step to `scripts/quality-gates.sh` that scans for email patterns (excluding allowed test domains). This provides a fail-fast mechanism for developers to ensure PII is not committed, aligning the codebase with its stated privacy goals.
+
+## 2025-04-07 - Secure Configuration Loading Pattern
+**Vulnerability:** Denial of Service (DoS) via memory exhaustion when loading untrusted or oversized configuration files.
+**Learning:** Standard `std::fs::read_to_string` is susceptible to memory exhaustion if the input file is large or is a special device (like `/dev/zero`) that provides an infinite stream. Simple `metadata.len()` checks can be bypassed by TOCTOU or special files reporting zero size.
+**Prevention:** Use a multi-layered approach: 1) Open the file first, 2) Verify it is a regular file using `file.metadata()?.is_file()`, 3) Enforce a strict size limit using `file.take(limit).read_to_string(&mut contents)`. This ensures predictable memory usage and prevents blocking on non-regular files.

--- a/crates/sample-app/src/main.rs
+++ b/crates/sample-app/src/main.rs
@@ -15,6 +15,7 @@
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use std::fmt::Write;
+use std::io::Read;
 use std::path::PathBuf;
 use thiserror::Error;
 use tracing::{error, info, warn};
@@ -79,9 +80,35 @@ struct Args {
 
 /// Load configuration from file or use defaults
 fn load_config(config_path: Option<PathBuf>) -> Result<Config> {
+    // Security: Check file size before reading to prevent DoS (memory exhaustion)
+    // Use a 1MB limit for configuration files
+    const MAX_CONFIG_SIZE: u64 = 1024 * 1024;
+
     if let Some(path) = config_path {
-        info!("Loading config from: {:?}", path);
-        let contents = std::fs::read_to_string(&path)?;
+        info!("Loading config from: {}", path.display());
+
+        let file = std::fs::File::open(&path)?;
+        let metadata = file.metadata()?;
+
+        if !metadata.is_file() {
+            return Err(AppError::Config(format!(
+                "Config path is not a regular file: {}",
+                path.display()
+            )));
+        }
+
+        let file_size = metadata.len();
+        if file_size > MAX_CONFIG_SIZE {
+            return Err(AppError::Config(format!(
+                "Config file too large: {file_size} bytes (max {MAX_CONFIG_SIZE})"
+            )));
+        }
+
+        // Capacity is safe to cast as we just checked against 1MB MAX_CONFIG_SIZE
+        #[allow(clippy::cast_possible_truncation)]
+        let mut contents = String::with_capacity(file_size as usize);
+        file.take(MAX_CONFIG_SIZE).read_to_string(&mut contents)?;
+
         let config: Config = serde_json::from_str(&contents)?;
         Ok(config)
     } else {


### PR DESCRIPTION
🛡️ Severity: MEDIUM
💡 Vulnerability: Configuration loading in `sample-app` was using `std::fs::read_to_string` directly on a path provided by CLI/Config without size or file type validation. This could lead to Denial of Service (DoS) via memory exhaustion if a very large file or a special device like `/dev/zero` was passed as a configuration path.
🎯 Impact: Attacker could cause the application to crash or consume excessive memory, affecting availability.
🔧 Fix: Enhanced `load_config` to 1) verify the path is a regular file, 2) check metadata length, and 3) use `Read::take` to strictly enforce a 1MB limit during the read operation.
✅ Verification: Verified with `cargo test --workspace` and `scripts/quality-gates.sh`. The fix addresses the TOCTOU and special file vulnerabilities identified during code review.

---
*PR created automatically by Jules for task [5164248616899661824](https://jules.google.com/task/5164248616899661824) started by @d-oit*