### PR TITLE
Bolt: [performance improvement] Optimize CLI output by locking stdout

### DIFF
--- a/crates/sample-app/src/main.rs
+++ b/crates/sample-app/src/main.rs
@@ -195,12 +195,19 @@ async fn main() -> Result<()> {
     let items = process_items(args.count)?;
 
     // Print results
-    println!("\nProcessed {} items:", items.len());
-    for item in items.iter().take(5) {
-        println!("  - {item}");
-    }
-    if items.len() > 5 {
-        println!("  ... and {} more", items.len() - 5);
+    // Bolt: Lock stdout to minimize locking overhead and syscalls for multiple prints
+    {
+        use std::io::Write;
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        let _ = writeln!(handle, "\nProcessed {} items:", items.len());
+        for item in items.iter().take(5) {
+            let _ = writeln!(handle, "  - {item}");
+        }
+        if items.len() > 5 {
+            let _ = writeln!(handle, "  ... and {} more", items.len() - 5);
+        }
+        let _ = handle.flush();
     }
 
     info!("Application completed successfully");


### PR DESCRIPTION
What: Optimized the CLI output in `sample-app` by explicitly locking `stdout` and using `writeln!` on the locked handle.
Why: The `println!` macro acquires and releases a lock on `stdout` for every call. For multiple consecutive writes, locking once reduces synchronization overhead and potentially the number of system calls.
Impact: Reduces locking overhead during the result printing phase of the application.
Measurement: Verified via code review and successful execution of all quality gates.

---
*PR created automatically by Jules for task [7327009123629199455](https://jules.google.com/task/7327009123629199455) started by @d-oit*