### PR TITLE
feat: documentation sync + label automation + patch release workflow

### DIFF
--- a/.agents/SKILLS.md
+++ b/.agents/SKILLS.md
@@ -1,7 +1,7 @@
 # Agent Skills Index
 
-This directory contains reusable agent skills for working with this Rust template repository.
-Skills are self-contained runbooks that AI agents (Claude, Gemini, Copilot, etc.) can follow.
+Reusable skill runbooks for working with this Rust template repository.
+Skills are self-contained and can be followed by Claude Code, Gemini CLI, OpenCode, Qwen Code, and similar agents.
 
 ## Available Skills
 
@@ -10,7 +10,12 @@ Skills are self-contained runbooks that AI agents (Claude, Gemini, Copilot, etc.
 | `build-rust` | [skills/build-rust/SKILL.md](skills/build-rust/SKILL.md) | Compile, build, and verify Rust code |
 | `lint-rust` | [skills/lint-rust/SKILL.md](skills/lint-rust/SKILL.md) | Run Clippy, format checks, cargo-audit, cargo-deny |
 | `test-rust` | [skills/test-rust/SKILL.md](skills/test-rust/SKILL.md) | Run test suite with cargo-nextest |
-| `release-rust` | [skills/release-rust/SKILL.md](skills/release-rust/SKILL.md) | Create releases with cargo-dist |
+| `release-rust` | [skills/release-rust/SKILL.md](skills/release-rust/SKILL.md) | Safe release workflow for crates.io |
+| `crates-io-name-check` | [skills/crates-io-name-check/SKILL.md](skills/crates-io-name-check/SKILL.md) | Verify crate name availability before publishing |
+| `anti-ai-slop` | [skills/anti-ai-slop/SKILL.md](skills/anti-ai-slop/SKILL.md) | Audit and fix generic AI-generated Rust code patterns |
+| `privacy-first` | [skills/privacy-first/SKILL.md](skills/privacy-first/SKILL.md) | Prevent email/personal data from entering the codebase |
+| `skill-creator` | [skills/skill-creator/SKILL.md](skills/skill-creator/SKILL.md) | Create and optimize new agent skills |
+| `skill-evaluator` | [skills/skill-evaluator/SKILL.md](skills/skill-evaluator/SKILL.md) | Evaluate skill quality with structure checks |
 
 ## Skill Format
 
@@ -30,7 +35,7 @@ Each skill follows this structure:
 
 ## Usage by AI Agents
 
-When an AI agent needs to perform a task, it should:
+When an AI agent needs to perform a task:
 1. Check this index for the relevant skill
 2. Follow the skill's steps exactly
 3. Report results against the success criteria
@@ -44,6 +49,8 @@ When an AI agent needs to perform a task, it should:
 4. Reference the skill in `AGENTS.md` if applicable
 
 ## Related Files
-- [AGENTS.md](../AGENTS.md) - General agent guidelines
-- [CLAUDE.md](../CLAUDE.md) - Claude-specific instructions
-- [GEMINI.md](../GEMINI.md) - Gemini-specific instructions
+
+- [AGENTS.md](../AGENTS.md) — General agent guidelines
+- [CLAUDE.md](../CLAUDE.md) — Claude-specific instructions
+- [GEMINI.md](../GEMINI.md) — Gemini-specific instructions
+- [agents-docs/workflow.md](../agents-docs/workflow.md) — Skill + CLI usage pattern

--- a/.github/workflows/patch-release-on-label.yml
+++ b/.github/workflows/patch-release-on-label.yml
@@ -1,0 +1,155 @@
+# .github/workflows/patch-release-on-label.yml
+#
+# Trigger : PR labelled with `release:patch`
+# Effect  : bumps the patch version in every relevant file on the PR branch,
+#           then commits the changes back.
+#
+# Canonical version source : [workspace.package] version in Cargo.toml
+# Files updated by scripts/bump-version.sh:
+#   - Cargo.toml              ([workspace.package] version)
+#   - crates/*/Cargo.toml     (any crate with a standalone version line)
+#   - Cargo.lock              (regenerated via `cargo update --workspace`)
+#   - CHANGELOG.md            ([Unreleased] → [X.Y.Z], new [Unreleased] header,
+#                              diff links)
+#   - README.md               (explicit version strings)
+#   - *.md / *.yml / *.yaml / *.json  (lines matching `version = "OLD"` or
+#                              `version: "OLD"` exactly — dependency specs are
+#                              left untouched)
+#
+# Loop prevention : the bot commit sets `skip-checks: true` and the job guards
+#   on `github.actor != 'github-actions[bot]'` so re-labelling by the bot
+#   never re-triggers the workflow.
+
+name: Patch Release on Label
+
+on:
+  pull_request:
+    types: [labeled]
+
+# One run per PR at a time; cancel any queued run for the same PR.
+concurrency:
+  group: patch-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write   # push commit to PR branch
+  pull-requests: read
+
+jobs:
+  bump-patch:
+    name: Bump patch version
+    # Guard 1: only the exact label we care about
+    if: >
+      github.event.label.name == 'release:patch' &&
+      github.event.pull_request.state == 'open' &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── Checkout the PR branch (full history for CHANGELOG links) ───────────
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          # Use a PAT or the default GITHUB_TOKEN.
+          # GITHUB_TOKEN pushes are visible to CI but won't re-trigger
+          # `pull_request` events, which is exactly what we want.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      # ── Install stable Rust (needed for `cargo update`) ─────────────────────
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # ── Cache Cargo registry to speed up `cargo update` ─────────────────────
+      - name: Cache Cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      # ── Run the version bump script ──────────────────────────────────────────
+      - name: Bump patch version
+        id: bump
+        run: |
+          # Make script executable in case file permissions were lost
+          chmod +x scripts/bump-version.sh
+
+          # Capture old version before the bump
+          OLD=$(awk '
+            /^\[workspace\.package\]/ { in_section=1; next }
+            /^\[/                     { in_section=0 }
+            in_section && /^version[[:space:]]*=/ {
+              match($0, /"([0-9]+\.[0-9]+\.[0-9]+)"/, arr)
+              if (arr[1] != "") { print arr[1]; exit }
+            }
+          ' Cargo.toml)
+
+          # Apply the bump
+          bash scripts/bump-version.sh --execute
+
+          # Capture new version after the bump
+          NEW=$(awk '
+            /^\[workspace\.package\]/ { in_section=1; next }
+            /^\[/                     { in_section=0 }
+            in_section && /^version[[:space:]]*=/ {
+              match($0, /"([0-9]+\.[0-9]+\.[0-9]+)"/, arr)
+              if (arr[1] != "") { print arr[1]; exit }
+            }
+          ' Cargo.toml)
+
+          echo "old_version=$OLD" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW" >> "$GITHUB_OUTPUT"
+
+      # ── Commit and push if anything changed ──────────────────────────────────
+      - name: Commit version bump
+        env:
+          OLD: ${{ steps.bump.outputs.old_version }}
+          NEW: ${{ steps.bump.outputs.new_version }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Stage only the files the bump script touches; never stage unrelated
+          # working-tree changes that might exist on the branch.
+          git add \
+            Cargo.toml \
+            Cargo.lock \
+            CHANGELOG.md \
+            README.md \
+            "crates/*/Cargo.toml" \
+            "*.md" \
+            "*.yml" \
+            "*.yaml" \
+            "*.json" \
+            2>/dev/null || true
+
+          # Only commit if there is actually something staged
+          if git diff --cached --quiet; then
+            echo "Nothing to commit — version may already be $NEW"
+            exit 0
+          fi
+
+          git commit \
+            --message "chore(release): bump version $OLD → $NEW [skip ci]" \
+            --message "Automated patch version bump triggered by 'release:patch' label." \
+            --message "Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}
+
+      # ── Surface the result as a job summary ──────────────────────────────────
+      - name: Write job summary
+        if: always()
+        env:
+          OLD: ${{ steps.bump.outputs.old_version }}
+          NEW: ${{ steps.bump.outputs.new_version }}
+        run: |
+          echo "## Patch release bump" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | Version |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Before | \`$OLD\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| After  | \`$NEW\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Files updated: \`Cargo.toml\`, \`Cargo.lock\`, \`CHANGELOG.md\`, \`README.md\`, matching \`*.md / *.yml / *.yaml / *.json\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> Merge this PR to ship \`v$NEW\`. The release workflow fires on the resulting version tag." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,126 @@
+# .github/workflows/sync-labels.yml
+#
+# Runs scripts/learn-labels.sh to discover and create missing labels by
+# mining the repo's own activity (commits, issues, PRs, file paths).
+#
+# Triggers:
+#   schedule   — 1st of every month at 08:00 UTC
+#   workflow_dispatch — manual run with optional inputs
+#
+# No external AI API is used. All signal comes from the GitHub API.
+# Labels are only ever created, never deleted (safe by design).
+
+name: Sync Labels (Self-Learning)
+
+on:
+  schedule:
+    # 1st of every month, 08:00 UTC
+    - cron: "0 8 1 * *"
+
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Lookback window in days (default: 90)"
+        required: false
+        default: "90"
+      dry_run:
+        description: "Dry-run only — report candidates without creating labels"
+        required: false
+        type: boolean
+        default: false
+
+# Only one sync at a time; a manual run cancels any queued scheduled run.
+concurrency:
+  group: sync-labels
+  cancel-in-progress: true
+
+permissions:
+  # `issues: write` is the minimum scope required by `gh label create`.
+  # contents: read is needed to clone the repo for git log analysis.
+  contents: read
+  issues: write
+
+jobs:
+  learn-and-sync:
+    name: Learn & sync labels
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── Checkout (needed for git log commit-message analysis) ───────────────
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Fetch enough history for the lookback window.
+          # 200 commits covers most monthly windows; increase if needed.
+          fetch-depth: 200
+
+      # ── Resolve inputs (schedule has no inputs object) ──────────────────────
+      - name: Resolve inputs
+        id: inputs
+        run: |
+          # workflow_dispatch sets github.event.inputs; schedule leaves it null.
+          DAYS="${{ github.event.inputs.days || '90' }}"
+          DRY_RUN="${{ github.event.inputs.dry_run || 'false' }}"
+          echo "days=$DAYS"       >> "$GITHUB_OUTPUT"
+          echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+          echo "Lookback: $DAYS days | Dry-run: $DRY_RUN"
+
+      # ── Run the learning script ─────────────────────────────────────────────
+      - name: Learn and sync labels
+        id: sync
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x scripts/learn-labels.sh
+
+          DAYS="${{ steps.inputs.outputs.days }}"
+          DRY_RUN="${{ steps.inputs.outputs.dry_run }}"
+
+          ARGS=(--days "$DAYS" --repo "${{ github.repository }}")
+          [[ "$DRY_RUN" == "false" ]] && ARGS+=(--execute)
+
+          bash scripts/learn-labels.sh "${ARGS[@]}" | tee /tmp/learn-output.txt
+
+          # Parse the SUMMARY line into step outputs
+          SUMMARY=$(grep '^SUMMARY:' /tmp/learn-output.txt || echo "SUMMARY: existing=0 candidates=0 created=0 skipped=0 stale=0")
+          parse() { echo "$SUMMARY" | grep -oP "(?<=${1}=)[0-9]+"; }
+
+          echo "existing=$(parse existing)"     >> "$GITHUB_OUTPUT"
+          echo "candidates=$(parse candidates)" >> "$GITHUB_OUTPUT"
+          echo "created=$(parse created)"       >> "$GITHUB_OUTPUT"
+          echo "stale=$(parse stale)"           >> "$GITHUB_OUTPUT"
+
+      # ── Write a rich job summary ────────────────────────────────────────────
+      - name: Write job summary
+        if: always()
+        env:
+          DAYS:       ${{ steps.inputs.outputs.days }}
+          DRY_RUN:    ${{ steps.inputs.outputs.dry_run }}
+          EXISTING:   ${{ steps.sync.outputs.existing }}
+          CANDIDATES: ${{ steps.sync.outputs.candidates }}
+          CREATED:    ${{ steps.sync.outputs.created }}
+          STALE:      ${{ steps.sync.outputs.stale }}
+        run: |
+          {
+            echo "## Label sync — $(date -u +%Y-%m-%d)"
+            echo ""
+            echo "| Metric | Value |"
+            echo "|---|---|"
+            echo "| Lookback window | ${DAYS} days |"
+            echo "| Dry-run | ${DRY_RUN} |"
+            echo "| Existing labels | ${EXISTING} |"
+            echo "| New candidates found | ${CANDIDATES} |"
+            echo "| Labels created | ${CREATED} |"
+            echo "| Stale labels (unused) | ${STALE} |"
+            echo ""
+            echo "### Signal sources"
+            echo "- Conventional-commit prefixes in recent commits"
+            echo "- Recurring keywords in closed issue and merged PR bodies"
+            echo "- File paths touched in recent PRs (area labels)"
+            echo "- Label usage frequency (stale detection)"
+            echo ""
+            echo "### Full output"
+            echo '```'
+            cat /tmp/learn-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Initial project structure
+- `sample-app` binary crate: tokio, clap, serde/serde_json, tracing, thiserror, anyhow
+  - CLI flags: `--count`, `--verbose`, `--config`
+  - JSON config loading with 1 MB size guard and `#[serde(deny_unknown_fields)]`
+  - Typed `AppError` enum via `thiserror`
+- `scripts/release-manager.sh`: dry-run release workflow (validate / prepare / publish)
+- `scripts/code-quality.sh`: fmt | clippy | audit | check | fix operations
+- Cargo aliases in `.cargo/config.toml`: `check-all`, `test-all`, `fmt-check`, `lint`, `audit-check`, `release-check`
+- 9-step `scripts/quality-gates.sh` with `--fix` flag (adds unused-deps, privacy, and secret scans)
+- 9 agent skills: `anti-ai-slop`, `build-rust`, `crates-io-name-check`, `lint-rust`, `privacy-first`, `release-rust`, `skill-creator`, `skill-evaluator`, `test-rust`
+- `docs/architecture/context.yaml` for AI agent context
+- `plans/GOAP_STATE.md` for AI agent world state tracking
+- GitHub issue templates: `bug_report.yml`, `feature_request.yml`
 
 ### Changed
-- Updated toolchain from 1.85 to 1.87
-- Updated tokio features from "full" to specific features (rt-multi-thread, macros, sync, time, fs)
-
-### Deprecated
-
-### Removed
+- Toolchain bumped from 1.85 to 1.87 (`rust-toolchain.toml` and `Cargo.toml` `rust-version`)
+- `tokio` features narrowed from `"full"` to `rt-multi-thread, macros, sync, time, fs`
+- `serde` pinned to `=1.0.194`, `serde_json` to `=1.0.140`, `insta` to `=1.40.0`
+- CI: sccache disabled for `cargo-deny` job (runs in Docker without sccache)
+- CI: mold linker installed for `clippy`, `test`, and `msrv` jobs
 
 ### Fixed
-- Added missing documentation for enum variants in sample-app
-- Fixed CLI argument short name conflict (-c)
-- Fixed clippy warnings: single_match_else, uninlined_format_args, needless_borrows_for_generic_args
-- Added mold linker installation for clippy and MSRV CI jobs
-- Added Unicode-3.0 license to allowed licenses
-
-### Security
+- Missing doc comments on `AppError` enum variants
+- CLI short flag conflict (`-c` for `--count`)
+- Clippy warnings: `single_match_else`, `uninlined_format_args`, `needless_borrows_for_generic_args`
+- `Unicode-3.0` added to allowed licenses in `deny.toml`
 
 ---
 
@@ -43,5 +50,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rust 2024 edition formatting (rustfmt.toml)
 - Clippy configuration (.clippy.toml)
 
-[Unreleased]: https://github.com/OWNER/REPO/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/OWNER/REPO/releases/tag/v0.1.0
+[Unreleased]: https://github.com/d-oit/rust-2026-template/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/d-oit/rust-2026-template/releases/tag/v0.1.0

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,7 +4,7 @@ Get a new Rust project running in under 5 minutes.
 
 ## Prerequisites
 
-- Rust stable via [rustup](https://rustup.rs/) (toolchain version is pinned in `rust-toolchain.toml`)
+- Rust stable via [rustup](https://rustup.rs/) — toolchain pinned to 1.87 in `rust-toolchain.toml`
 - Git 2.30+
 - Optional: `cargo-nextest`, `cargo-deny`, `cargo-audit` for full quality gates
 
@@ -36,6 +36,8 @@ mv crates/example-crate crates/your-crate-name
 
 See `.agents/skills/crates-io-name-check/SKILL.md` for the full name-check workflow.
 
+The `sample-app` binary crate can be kept as a reference or renamed/removed as needed.
+
 ## 3. Install Required Tools
 
 ```bash
@@ -50,8 +52,15 @@ cargo install cargo-audit
 ## 4. Build and Test
 
 ```bash
-cargo build
-cargo nextest run
+# Build all workspace crates
+cargo build --workspace
+
+# Run all tests
+cargo nextest run --workspace
+
+# Run the sample app
+cargo run -p sample-app
+cargo run -p sample-app -- --count 5 --verbose
 ```
 
 ## 5. Run All Quality Gates
@@ -60,7 +69,13 @@ cargo nextest run
 bash scripts/quality-gates.sh
 ```
 
-Expected output: all checks green.
+Runs 9 checks: format, clippy, build, tests, doc tests, security audit, cargo-deny, unused deps, privacy scan, secret scan.
+
+Pass `--fix` to auto-correct formatting and clippy issues:
+
+```bash
+bash scripts/quality-gates.sh --fix
+```
 
 ## 6. Update Project Metadata
 
@@ -68,7 +83,8 @@ Edit these files with your project details:
 
 | File | What to update |
 |---|---|
-| `Cargo.toml` | `name`, `description`, `repository`, `homepage` |
+| `Cargo.toml` | `authors`, `repository`, `homepage`, `documentation` |
+| `crates/*/Cargo.toml` | `name`, `description` |
 | `AGENTS.md` | Project name, description, domain context |
 | `CLAUDE.md` | Project-specific overrides |
 | `README.md` | Replace template content with your project |
@@ -83,7 +99,7 @@ git commit -m "feat: initialize project from rust-2026-template"
 git push origin main
 ```
 
-CI will run: format check, clippy, tests, security audit, dependency policy.
+CI runs: format check, clippy, nextest, doc tests, security audit, cargo-deny, MSRV check.
 
 ---
 
@@ -92,13 +108,16 @@ CI will run: format check, clippy, tests, security audit, dependency policy.
 | Component | Location | Purpose |
 |---|---|---|
 | CI pipeline | `.github/workflows/ci.yml` | Format, lint, test, audit on every push |
-| Release workflow | `.github/workflows/release.yml` | Automated publishing to crates.io |
-| Agent skills | `.agents/skills/` | AI coding assistant knowledge modules |
-| Quality gate | `scripts/quality-gates.sh` | Local pre-push checks |
+| Release workflow | `.github/workflows/release.yml` | Tag-triggered release with cargo-dist |
+| Agent skills | `.agents/skills/` | 9 AI coding assistant skill runbooks |
+| Quality gate script | `scripts/quality-gates.sh` | 9-step local pre-push checks |
+| Code quality script | `scripts/code-quality.sh` | fmt \| clippy \| audit \| check \| fix |
+| Release manager | `scripts/release-manager.sh` | validate \| prepare \| publish |
 | ADR template | `plans/adr/` | Architecture decision records |
 | Clippy config | `.clippy.toml` | Pedantic lint rules |
 | Deny config | `deny.toml` | License and vulnerability policy |
-| Nextest config | `.config/nextest.toml` | Test profiles (local + CI) |
+| Nextest config | `.config/nextest.toml` | Test profiles (default + ci) |
+| Cargo aliases | `.cargo/config.toml` | `check-all`, `test-all`, `lint`, etc. |
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -4,34 +4,40 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust 1.87+](https://img.shields.io/badge/rust-1.87%2B-orange.svg)](https://www.rust-lang.org)
 
-Best practice 2026 Rust GitHub repository template with AI agent support, CI/CD, quality gates, and all modern Rust tooling.
+Best practice 2026 Rust GitHub repository template with AI agent support, CI/CD, quality gates, and modern Rust tooling.
 
 ## Features
 
-- **Workspace structure** - Multi-crate Cargo workspace with `crates/` layout
-- **2026 Rust edition** - Rust edition 2024, MSRV 1.87
-- **CI/CD pipeline** - Full GitHub Actions CI with format, clippy, test, security audit, cargo-deny, MSRV check
-- **AI agent support** - `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `QWEN.md`, `opencode.json` for AI coding assistants
-- **Agent skills** - `.agents/skills/` directory with 9 reusable agent skill files
-- **Quality gates** - `scripts/quality-gates.sh` for local quality checks
-- **Architecture decisions** - `plans/adr/` with ADR template
-- **Supply chain security** - `deny.toml` with cargo-deny v2 configuration
-- **Modern linting** - `.clippy.toml` with pedantic lints
-- **Formatting** - `rustfmt.toml` with Rust 2024 edition settings
-- **VSCode** - `.vscode/settings.json` with rust-analyzer and WSL2 support
-- **cargo-nextest** - `.config/nextest.toml` with CI profile
-- **Documentation** - `QUICKSTART.md`, `CONTRIBUTING.md`, `SECURITY.md`, `MIGRATION.md`
+- **Workspace structure** — Multi-crate Cargo workspace with `crates/` layout; includes `example-crate` (library) and `sample-app` (binary)
+- **Rust 2024 edition** — MSRV 1.87, pinned via `rust-toolchain.toml`
+- **CI/CD pipeline** — GitHub Actions: format, clippy, nextest, security audit, cargo-deny, MSRV check, release
+- **AI agent support** — `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `QWEN.md`, `opencode.json`
+- **Agent skills** — `.agents/skills/` with 9 reusable skill files
+- **Quality gates** — `scripts/quality-gates.sh` (9 checks) and `scripts/code-quality.sh`
+- **Supply chain security** — `deny.toml` with cargo-deny v2; `cargo-audit` in CI
+- **Modern linting** — `.clippy.toml` with pedantic lints; zero-warnings policy
+- **Formatting** — `rustfmt.toml` with Rust 2024 edition settings
+- **WSL2/Linux optimizations** — mold linker, disk-space-optimized dev profile in `.cargo/config.toml`
+- **cargo-nextest** — `.config/nextest.toml` with `default` and `ci` profiles
+- **Architecture docs** — `plans/adr/`, `docs/architecture/context.yaml`, `agents-docs/`
 
 ## Quick Start
 
-See **[QUICKSTART.md](QUICKSTART.md)** for the full 5-minute setup guide.
+See **[QUICKSTART.md](QUICKSTART.md)** for the full setup guide.
 
-1. Click **"Use this template"** on GitHub to create a new repo
-2. **Check crates.io** for your crate name: `cargo search your-crate-name`
-3. Rename `example-crate` under `crates/` with your own crate(s)
-4. Update `Cargo.toml` workspace metadata (name, authors, repository, etc.)
-5. Update `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` with your project details
-6. Push to `main` and watch CI pass!
+1. Click **"Use this template"** on GitHub
+2. Check crates.io availability: `cargo search your-crate-name`
+3. Rename `crates/example-crate` to your crate name
+4. Update `Cargo.toml` workspace metadata
+5. Update agent instruction files with your project details
+6. Push to `main` — CI runs automatically
+
+## Workspace Crates
+
+| Crate | Type | Description |
+|---|---|---|
+| [`example-crate`](crates/example-crate/) | Library | Minimal library placeholder — rename and replace |
+| [`sample-app`](crates/sample-app/) | Binary | Full-featured app demonstrating tokio, clap, serde, tracing, thiserror |
 
 ## Agent Skills
 
@@ -43,96 +49,132 @@ All skills live in `.agents/skills/` and are compatible with Claude Code, OpenCo
 | [`lint-rust`](.agents/skills/lint-rust/) | Run clippy and formatting checks |
 | [`test-rust`](.agents/skills/test-rust/) | Run tests with cargo-nextest |
 | [`release-rust`](.agents/skills/release-rust/) | Safe release workflow for crates.io |
-| [`crates-io-name-check`](.agents/skills/crates-io-name-check/) | Verify crate name is unique before publishing |
-| [`anti-ai-slop`](.agents/skills/anti-ai-slop/) | Audit/fix generic AI-generated Rust code patterns |
-| [`privacy-first`](.agents/skills/privacy-first/) | Prevent email/personal data from entering codebase |
+| [`crates-io-name-check`](.agents/skills/crates-io-name-check/) | Verify crate name availability before publishing |
+| [`anti-ai-slop`](.agents/skills/anti-ai-slop/) | Audit and fix generic AI-generated Rust code patterns |
+| [`privacy-first`](.agents/skills/privacy-first/) | Prevent email/personal data from entering the codebase |
 | [`skill-creator`](.agents/skills/skill-creator/) | Create and optimize new agent skills |
-| [`skill-evaluator`](.agents/skills/skill-evaluator/) | Evaluate skill quality with structure checks and evals |
+| [`skill-evaluator`](.agents/skills/skill-evaluator/) | Evaluate skill quality with structure checks |
 
 ## AI Agent Integration
 
-This template includes instruction files for popular AI coding assistants:
-
-- **`AGENTS.md`** - For OpenAI Codex and compatible agents
-- **`CLAUDE.md`** - For Claude Code (Anthropic)
-- **`GEMINI.md`** - For Gemini CLI (Google)
-- **`QWEN.md`** - For Qwen Code
-- **`opencode.json`** - OpenCode configuration
-- **`.agents/skills/`** - Reusable agent skill files for common tasks
+| File | Agent |
+|---|---|
+| `AGENTS.md` | OpenAI Codex and compatible agents |
+| `CLAUDE.md` | Claude Code (Anthropic) |
+| `GEMINI.md` | Gemini CLI (Google) |
+| `QWEN.md` | Qwen Code |
+| `opencode.json` | OpenCode configuration |
+| `.agents/skills/` | Reusable skill runbooks |
 
 ## Repository Structure
 
 ```
 rust-2026-template/
 ├── .agents/
-│   └── skills/          # AI agent skill files (9 skills)
+│   ├── SKILLS.md            # Skills index
+│   └── skills/              # 9 AI agent skill files
 ├── .cargo/
-│   └── config.toml      # Cargo config (WSL2, sparse registry)
+│   └── config.toml          # Linker, dev profile, cargo aliases
 ├── .config/
-│   └── nextest.toml     # cargo-nextest profiles (default, ci)
+│   └── nextest.toml         # nextest profiles (default, ci)
 ├── .github/
-│   ├── ISSUE_TEMPLATE/  # GitHub issue templates
+│   ├── ISSUE_TEMPLATE/      # Bug report + feature request templates
 │   ├── PULL_REQUEST_TEMPLATE.md
+│   ├── dependabot.yml
 │   └── workflows/
-│       ├── ci.yml           # Main CI pipeline
-│       └── release.yml      # Release workflow
+│       ├── ci.yml           # Format, clippy, test, audit, deny, MSRV
+│       └── release.yml      # Tag-triggered release with cargo-dist
 ├── .vscode/
-│   └── settings.json    # VSCode + rust-analyzer settings
+│   └── settings.json        # rust-analyzer + WSL2 settings
+├── agents-docs/             # Agent reference docs
+│   ├── commands.md
+│   ├── conventions.md
+│   ├── structure.md
+│   └── workflow.md
 ├── crates/
-│   └── example-crate/   # Replace with your crate(s)
+│   ├── example-crate/       # Library placeholder
+│   └── sample-app/          # Binary: tokio, clap, serde, tracing
+├── docs/
+│   └── architecture/
+│       └── context.yaml
 ├── plans/
-│   └── adr/             # Architecture Decision Records
+│   ├── GOAP_STATE.md        # AI agent world state
+│   └── adr/                 # Architecture Decision Records
 ├── scripts/
-│   └── quality-gates.sh # Local quality gate runner
-├── .clippy.toml         # Clippy lint configuration
-├── .gitignore           # Rust + WSL2 + IDE gitignore
-├── AGENTS.md            # AI agent instructions
-├── CHANGELOG.md         # Keep-a-changelog format
-├── CLAUDE.md            # Claude Code instructions
-├── CONTRIBUTING.md      # Contribution guidelines
-├── Cargo.toml           # Workspace Cargo manifest
-├── GEMINI.md            # Gemini CLI instructions
-├── LICENSE              # MIT license
-├── MIGRATION.md         # Template adoption & upgrade guide
-├── QUICKSTART.md        # 5-minute setup guide
-├── QWEN.md              # Qwen Code instructions
-├── SECURITY.md          # Security policy
-├── deny.toml            # cargo-deny v2 supply chain config
-├── opencode.json        # OpenCode configuration
-├── rust-toolchain.toml  # Pinned stable toolchain
-└── rustfmt.toml         # Rustfmt 2024 edition settings
+│   ├── code-quality.sh      # fmt | clippy | audit | check | fix
+│   ├── quality-gates.sh     # 9-step local quality gate runner
+│   └── release-manager.sh   # validate | prepare | publish
+├── src/
+│   └── lib.rs               # Workspace-level lib template stub
+├── .clippy.toml             # Clippy lint configuration
+├── .gitignore
+├── AGENTS.md                # AI agent instructions
+├── CHANGELOG.md
+├── CLAUDE.md
+├── CONTRIBUTING.md
+├── Cargo.toml               # Workspace manifest
+├── GEMINI.md
+├── LICENSE                  # MIT
+├── MIGRATION.md
+├── QUICKSTART.md
+├── QWEN.md
+├── SECURITY.md
+├── deny.toml                # cargo-deny v2 supply chain config
+├── opencode.json
+├── rust-toolchain.toml      # Pinned stable 1.87
+└── rustfmt.toml             # Rustfmt 2024 edition settings
 ```
 
 ## CI Pipeline
 
-The CI pipeline runs the following jobs on every push to `main`/`develop` and all PRs:
+Runs on every push to `main`/`develop` and all PRs:
 
 | Job | Tool | Purpose |
-|-----|------|---------|
-| Format | `cargo fmt` | Code formatting check |
-| Clippy | `cargo clippy` | Lint with all targets, all features, -D warnings |
-| Test | `cargo nextest` | Run tests with CI profile |
-| Security Audit | `cargo audit` | Check for known vulnerabilities |
+|---|---|---|
+| Format | `cargo fmt` | Formatting check |
+| Clippy | `cargo clippy` | All targets, all features, `-D warnings` |
+| Test | `cargo nextest` | Tests + doc tests, CI profile |
+| Security Audit | `cargo audit` | Known vulnerability check |
 | Dependency Policy | `cargo deny` | License and supply chain checks |
 | MSRV Check | `cargo check` | Verify MSRV 1.87 compatibility |
-| CI Success | Gate | All jobs must pass |
+| CI Success | Gate | All jobs must pass before merge |
 
 ## Local Quality Gates
 
-Run all quality checks locally before pushing:
+```bash
+# Run all 9 checks (mirrors CI)
+bash scripts/quality-gates.sh
+
+# Auto-fix formatting and clippy issues
+bash scripts/quality-gates.sh --fix
+
+# Individual operations
+./scripts/code-quality.sh fmt      # format
+./scripts/code-quality.sh clippy   # lint
+./scripts/code-quality.sh audit    # security audit
+./scripts/code-quality.sh check    # full CI parity
+```
+
+## Cargo Aliases
+
+Defined in `.cargo/config.toml`:
 
 ```bash
-bash scripts/quality-gates.sh
+cargo check-all     # cargo check --workspace --all-features
+cargo test-all      # cargo nextest run --workspace
+cargo fmt-check     # cargo fmt --all -- --check
+cargo lint          # cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo audit-check   # cargo deny check
 ```
 
 ## Documentation
 
-- 🚀 **[QUICKSTART.md](QUICKSTART.md)** - 5-minute setup guide
-- 🔧 **[CONTRIBUTING.md](CONTRIBUTING.md)** - How to contribute
-- 🔒 **[SECURITY.md](SECURITY.md)** - Security policy and vulnerability reporting
-- 🔄 **[MIGRATION.md](MIGRATION.md)** - Adopt template in existing projects / upgrade between versions
-- 📝 **[CHANGELOG.md](CHANGELOG.md)** - Version history
+- **[QUICKSTART.md](QUICKSTART.md)** — Setup guide
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — Contribution process
+- **[SECURITY.md](SECURITY.md)** — Security policy and vulnerability reporting
+- **[MIGRATION.md](MIGRATION.md)** — Adopt template in existing projects / upgrade between versions
+- **[CHANGELOG.md](CHANGELOG.md)** — Version history
 
 ## License
 
-MIT - see [LICENSE](LICENSE)
+MIT — see [LICENSE](LICENSE)

--- a/agents-docs/commands.md
+++ b/agents-docs/commands.md
@@ -5,27 +5,63 @@
 | Task | Command |
 |------|----------|
 | Build (dev) | `cargo build --workspace` |
+| Build (release) | `cargo build --workspace --release` |
 | Format | `./scripts/code-quality.sh fmt` |
 | Clippy | `./scripts/code-quality.sh clippy` |
 | Audit | `./scripts/code-quality.sh audit` |
-| Check | `./scripts/code-quality.sh check` |
-| Tests | `cargo nextest run --all` |
+| Full CI parity | `./scripts/code-quality.sh check` |
+| Auto-fix | `./scripts/code-quality.sh fix` |
+| Tests | `cargo nextest run --workspace` |
 | Doc tests | `cargo test --doc` |
-| Quality Gates | `./scripts/quality-gates.sh` |
-| Release validate | `./scripts/release-manager.sh validate` |
+| Quality Gates (all) | `./scripts/quality-gates.sh` |
+| Quality Gates (fix) | `./scripts/quality-gates.sh --fix` |
+
+## Cargo Aliases (`.cargo/config.toml`)
+
+| Alias | Expands to |
+|-------|-----------|
+| `cargo check-all` | `cargo check --workspace --all-features` |
+| `cargo test-all` | `cargo nextest run --workspace` |
+| `cargo fmt-check` | `cargo fmt --all -- --check` |
+| `cargo lint` | `cargo clippy --workspace --all-targets --all-features -- -D warnings` |
+| `cargo audit-check` | `cargo deny check` |
+| `cargo release-check` | `cargo semver-checks check-release` |
+
+## Targeted Commands
+
+```bash
+# Run tests for a single crate
+cargo nextest run -p example-crate
+cargo nextest run -p sample-app
+
+# Run the sample app
+cargo run -p sample-app
+cargo run -p sample-app -- --count 5 --verbose
+cargo run -p sample-app -- --config config.json
+```
 
 ## CI Parity
 
-| Check | Local Command |
-|-------|---------------|
-| Full CI Parity | `./scripts/code-quality.sh check` |
-| Clippy (tests) | `./scripts/code-quality.sh clippy` |
+| CI Job | Local Equivalent |
+|--------|-----------------|
+| Format | `cargo fmt --all -- --check` |
+| Clippy | `cargo clippy --workspace --all-targets --all-features -- -D warnings` |
+| Test | `cargo nextest run --workspace --all-features --profile ci` |
+| Doc tests | `cargo test --workspace --doc` |
+| Security | `cargo audit` |
+| Deny | `cargo deny check` |
+| MSRV | `rustup run 1.87 cargo check --workspace` |
 
 ## Release Workflow
 
 ```bash
-./scripts/quality-gates.sh
-cargo semver-checks check-release
+# 1. Validate (dry-run)
+./scripts/release-manager.sh validate
+
+# 2. Prepare version bump (dry-run)
+./scripts/release-manager.sh prepare patch
+
+# 3. Execute release
+./scripts/release-manager.sh validate --execute
 cargo release [patch|minor|major]
-./scripts/release-manager.sh --execute
 ```

--- a/agents-docs/structure.md
+++ b/agents-docs/structure.md
@@ -2,18 +2,76 @@
 
 ```
 rust-2026-template/
-├── .agents/skills/      # AI agent skill definitions
-├── .cargo/config.toml   # Cargo linker + profile config
-├── .claude/             # Claude-specific config
-├── .config/nextest.toml # nextest profiles
+├── .agents/
+│   ├── SKILLS.md            # Skills index
+│   └── skills/              # 9 AI agent skill runbooks
+│       ├── anti-ai-slop/
+│       ├── build-rust/
+│       ├── crates-io-name-check/
+│       ├── lint-rust/
+│       ├── privacy-first/
+│       ├── release-rust/
+│       ├── skill-creator/
+│       ├── skill-evaluator/
+│       └── test-rust/
+├── .cargo/
+│   └── config.toml          # Linker (mold), dev profile, cargo aliases
+├── .config/
+│   └── nextest.toml         # nextest profiles: default, ci
 ├── .github/
-│   ├── workflows/       # CI/CD GitHub Actions
-│   └── PULL_REQUEST_TEMPLATE.md
-├── .vscode/settings.json # VS Code / WSL2 settings
-├── scripts/             # Dev helper scripts
-├── plans/adr/           # Architecture Decision Records
-├── AGENTS.md            # AI agent instructions (this file)
-├── CLAUDE.md            # Claude: @AGENTS.md
-├── GEMINI.md            # Gemini: @AGENTS.md
-└── Cargo.toml           # Workspace manifest
+│   ├── ISSUE_TEMPLATE/      # bug_report.yml, feature_request.yml
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   ├── dependabot.yml
+│   └── workflows/
+│       ├── ci.yml           # Format, clippy, test, audit, deny, MSRV
+│       └── release.yml      # Tag-triggered release with cargo-dist
+├── .vscode/
+│   └── settings.json        # rust-analyzer + WSL2 settings
+├── agents-docs/             # Agent reference documentation
+│   ├── commands.md          # Command quick reference
+│   ├── conventions.md       # Code conventions and invariants
+│   ├── structure.md         # This file
+│   └── workflow.md          # Change workflow and skill/CLI pattern
+├── crates/
+│   ├── example-crate/       # Library placeholder (rename for your project)
+│   │   ├── Cargo.toml
+│   │   ├── README.md
+│   │   └── src/lib.rs
+│   └── sample-app/          # Binary: tokio, clap, serde, tracing, thiserror
+│       ├── Cargo.toml
+│       ├── README.md
+│       └── src/main.rs
+├── docs/
+│   └── architecture/
+│       └── context.yaml     # Architecture context for AI agents
+├── plans/
+│   ├── GOAP_STATE.md        # AI agent world state tracker
+│   └── adr/
+│       └── 0001-rust-edition-and-toolchain.md
+├── scripts/
+│   ├── code-quality.sh      # fmt | clippy | audit | check | fix
+│   ├── quality-gates.sh     # 9-step local quality gate runner (--fix flag)
+│   └── release-manager.sh   # validate | prepare | publish (dry-run by default)
+├── src/
+│   └── lib.rs               # Workspace-level lib stub (template placeholder)
+├── .clippy.toml             # Clippy lint configuration
+├── .envrc                   # direnv environment setup
+├── .gitignore
+├── AGENTS.md                # AI agent instructions
+├── CHANGELOG.md             # Keep-a-changelog format
+├── CLAUDE.md                # Claude Code: @AGENTS.md
+├── CONTRIBUTING.md
+├── Cargo.lock
+├── Cargo.toml               # Workspace manifest
+├── GEMINI.md                # Gemini CLI: @AGENTS.md
+├── LICENSE                  # MIT
+├── MIGRATION.md
+├── QUICKSTART.md
+├── QWEN.md                  # Qwen Code: @AGENTS.md
+├── SECURITY.md
+├── deny.toml                # cargo-deny v2 supply chain config
+├── flake.nix                # Nix flake (optional)
+├── opencode.json            # OpenCode configuration
+├── rust-toolchain.toml      # Pinned stable 1.87
+└── rustfmt.toml             # Rustfmt 2024 edition settings
 ```

--- a/crates/example-crate/README.md
+++ b/crates/example-crate/README.md
@@ -1,20 +1,41 @@
 # example-crate
 
-An example crate in the `rust-2026-template` workspace.
+Library placeholder in the `rust-2026-template` workspace. Rename this crate and replace its contents with your own implementation.
 
-## Overview
-
-This crate demonstrates the structure of a workspace member in the `rust-2026-template`.
-Replace this with your own crate description and implementation.
-
-## Usage
+## Current API
 
 ```rust
 use example_crate::greet;
 
 fn main() {
-    println!("{}", greet("world"));
+    println!("{}", greet("world")); // "Hello, world!"
 }
+```
+
+### `greet(name: &str) -> String`
+
+Returns `"Hello, {name}!"`. Demonstrates doc tests, `#[must_use]`, and `#[forbid(unsafe_code)]`.
+
+## Renaming This Crate
+
+```bash
+# 1. Check crates.io availability
+cargo search your-crate-name
+
+# 2. Rename the directory
+mv crates/example-crate crates/your-crate-name
+
+# 3. Update Cargo.toml
+# Change: name = "example-crate" -> name = "your-crate-name"
+```
+
+See `.agents/skills/crates-io-name-check/SKILL.md` for the full name-check workflow.
+
+## Testing
+
+```bash
+cargo nextest run -p example-crate
+cargo test --doc -p example-crate
 ```
 
 ## License

--- a/crates/sample-app/README.md
+++ b/crates/sample-app/README.md
@@ -1,47 +1,67 @@
-# Sample Application
+# sample-app
 
-A comprehensive sample application demonstrating the rust-2026-template features.
+Binary crate demonstrating `rust-2026-template` patterns: async runtime, CLI, structured logging, serialization, and error handling.
 
-## Features
+## Dependencies
 
-- **Async Runtime**: Uses tokio for async operations
-- **Error Handling**: Uses thiserror for custom errors and anyhow for context
-- **Serialization**: Uses serde for JSON serialization/deserialization
-- **Logging**: Uses tracing for structured logging
-- **CLI**: Uses clap for command-line argument parsing
+| Crate | Purpose |
+|---|---|
+| `tokio` | Async runtime (`current_thread` flavor) |
+| `clap` | CLI argument parsing with `derive` feature |
+| `serde` + `serde_json` | JSON config serialization |
+| `tracing` + `tracing-subscriber` | Structured logging |
+| `thiserror` | Typed error enum (`AppError`) |
+| `anyhow` | Error context propagation |
 
 ## Usage
 
 ```bash
-# Run with default settings
+# Run with defaults (processes 10 items)
 cargo run -p sample-app
 
-# Run with custom item count
+# Custom item count
 cargo run -p sample-app -- --count 5
 
-# Run with verbose logging
+# Verbose (DEBUG) logging
 cargo run -p sample-app -- --verbose
 
-# Run with config file
+# Load config from JSON file
 cargo run -p sample-app -- --config config.json
 ```
+
+### Config file format (`config.json`)
+
+```json
+{
+  "app_name": "my-app",
+  "log_level": "debug",
+  "max_items": 50
+}
+```
+
+Unknown fields are rejected (`#[serde(deny_unknown_fields)]`). Config files over 1 MB are rejected.
+
+## CLI Flags
+
+| Flag | Short | Default | Description |
+|---|---|---|---|
+| `--count` | `-c` | `10` | Number of items to process |
+| `--verbose` | `-v` | off | Enable DEBUG logging |
+| `--config` | — | none | Path to JSON config file |
 
 ## Testing
 
 ```bash
 # Run all tests
-cargo test -p sample-app
+cargo nextest run -p sample-app
 
-# Run with output
-cargo test -p sample-app -- --nocapture
+# Run with log output
+RUST_LOG=debug cargo nextest run -p sample-app -- --nocapture
 ```
 
 ## Building
 
 ```bash
-# Debug build
 cargo build -p sample-app
-
-# Release build
 cargo build -p sample-app --release
 ```

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -4,33 +4,42 @@
 ## State Variables (Executable Truth)
 
 ### Code Quality
-- `is_linted`: true (verified by CI - clippy passes with zero warnings)
-- `is_formatted`: true (verified by CI - cargo fmt passes)
-- `has_zero_warnings`: true (verified by CI - clippy -- -D warnings)
-- `is_semver_compliant`: false (not checked yet)
+- `is_linted`: true (CI — clippy passes with zero warnings, `-D warnings`)
+- `is_formatted`: true (CI — `cargo fmt --all -- --check` passes)
+- `has_zero_warnings`: true (CI — clippy all targets, all features)
+- `is_semver_compliant`: false (not checked yet — run `cargo semver-checks`)
 
 ### Testing
-- `has_unit_tests`: true (example-crate has unit tests)
+- `has_unit_tests`: true (`example-crate` and `sample-app` both have `#[cfg(test)]` modules)
 - `has_integration_tests`: false
-- `tests_passing`: true (verified by CI - cargo nextest passes)
-- `coverage_meets_target`: false (Target: 80%, not measured)
+- `tests_passing`: true (CI — `cargo nextest run --workspace --profile ci` passes)
+- `has_doc_tests`: true (`example-crate::greet` has a doc test)
+- `coverage_meets_target`: false (target: 80%, not measured)
+
+### Crates
+- `example_crate`: library placeholder — `greet(name) -> String`
+- `sample_app`: binary — tokio, clap, serde, tracing, thiserror; `--count`, `--verbose`, `--config` flags
 
 ### Documentation
-- `has_context_yaml`: true
+- `has_context_yaml`: true (`docs/architecture/context.yaml`)
 - `has_agents_md`: true
-- `is_architecture_documented`: true
+- `is_architecture_documented`: true (ADR 0001)
+- `readme_current`: true (updated to reflect two crates and all scripts)
 
 ### Git
 - `is_dirty`: false
 - `on_main`: true
 
 ## Current Phase
-`Phase 0: Initialization` - CI pipeline verified and working
+`Phase 0: Initialization` — CI pipeline verified and working, documentation updated
 
 ## Active Blockers
 - None
 
 ## Recent Changes
-- Fixed CI: installed mold linker for test job
-- Fixed CI: disabled sccache for cargo-deny job (runs in Docker container)
-- Verified ADR 0001 matches implementation (Rust 2024 edition, 1.85 toolchain)
+- Added `sample-app` binary crate (tokio, clap, serde, tracing, thiserror)
+- Added `scripts/release-manager.sh`
+- Fixed CI: installed mold linker for clippy, test, and MSRV jobs
+- Fixed CI: disabled sccache for cargo-deny job (runs in Docker)
+- Updated toolchain from 1.85 to 1.87
+- Updated all documentation to reflect current codebase

--- a/plans/adr/0001-rust-edition-and-toolchain.md
+++ b/plans/adr/0001-rust-edition-and-toolchain.md
@@ -1,7 +1,7 @@
 # ADR 0001: Rust Edition and Toolchain
 
 **Date**: 2025-01-01  
-**Status**: Accepted  
+**Status**: Accepted (updated 2026-04-17: toolchain bumped to 1.87)  
 **Deciders**: Template maintainers
 
 ## Context
@@ -11,7 +11,7 @@ The choice affects language features, compilation behavior, and ecosystem compat
 
 ## Decision
 
-Use **Rust 2024 edition** with a **pinned stable toolchain** (1.87+) via `rust-toolchain.toml`.
+Use **Rust 2024 edition** with a **pinned stable toolchain** (`1.87`) via `rust-toolchain.toml`.
 
 ## Rationale
 
@@ -20,11 +20,12 @@ Use **Rust 2024 edition** with a **pinned stable toolchain** (1.87+) via `rust-t
 - Stricter lifetime rules catch bugs earlier
 - Aligns with community best practices going forward
 
-### Pinned Stable Toolchain
+### Pinned Stable Toolchain (1.87)
 - Reproducible builds across all environments
 - `rust-toolchain.toml` is automatically respected by `rustup`
 - Avoids "works on my machine" issues from toolchain drift
 - nightly features are unstable; stable provides a guarantee
+- 1.87 is the current MSRV; bump `rust-toolchain.toml` and `Cargo.toml` `rust-version` together
 
 ### Why not nightly?
 - Nightly breaks periodically

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# scripts/bump-version.sh
+#
+# Canonical version source: [workspace.package] version in ./Cargo.toml
+#
+# What this script updates:
+#   1. Cargo.toml          — [workspace.package] version = "X.Y.Z"
+#   2. Cargo.lock          — regenerated via `cargo update --workspace`
+#   3. CHANGELOG.md        — promotes [Unreleased] to [X.Y.Z] and inserts a
+#                            fresh [Unreleased] header; updates diff links
+#   4. README.md           — badge URL containing the old version string
+#   5. Any *.md / *.toml / *.yml / *.yaml / *.json file that contains an
+#      explicit "version = \"OLD\"" or "version: OLD" line that matches the
+#      workspace version exactly (skips dependency version lines)
+#
+# Files intentionally NOT touched:
+#   - Dependency version specs in [dependencies] / [workspace.dependencies]
+#   - rust-toolchain.toml  (toolchain channel, not crate version)
+#   - deny.toml            (supply-chain policy, not crate version)
+#   - target/              (build artefacts)
+#   - .git/                (git internals)
+#
+# Usage:
+#   ./scripts/bump-version.sh            # dry-run: prints what would change
+#   ./scripts/bump-version.sh --execute  # applies all changes
+#
+# Exit codes:
+#   0  success (or dry-run completed)
+#   1  error (missing tools, parse failure, etc.)
+
+set -euo pipefail
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+info()  { echo -e "${CYAN}[bump]${NC} $*"; }
+ok()    { echo -e "${GREEN}[bump]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[bump]${NC} $*"; }
+die()   { echo -e "${RED}[bump] ERROR:${NC} $*" >&2; exit 1; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+EXECUTE=false
+for arg in "$@"; do
+  case "$arg" in
+    --execute) EXECUTE=true ;;
+    --help|-h)
+      sed -n '2,/^# Usage/p' "$0" | grep '^#' | sed 's/^# \?//'
+      exit 0
+      ;;
+    *) die "Unknown argument: $arg. Use --execute or --help." ;;
+  esac
+done
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+CARGO_TOML="$ROOT/Cargo.toml"
+[[ -f "$CARGO_TOML" ]] || die "Cargo.toml not found at $CARGO_TOML"
+
+# ── Read current version from [workspace.package] ────────────────────────────
+# Matches the first bare `version = "X.Y.Z"` line inside [workspace.package].
+# Uses awk so it is scoped to the correct TOML section and ignores dependency
+# version specs that appear later in the file.
+CURRENT_VERSION=$(awk '
+  /^\[workspace\.package\]/ { in_section=1; next }
+  /^\[/                     { in_section=0 }
+  in_section && /^version[[:space:]]*=/ {
+    match($0, /"([0-9]+\.[0-9]+\.[0-9]+)"/, arr)
+    if (arr[1] != "") { print arr[1]; exit }
+  }
+' "$CARGO_TOML")
+
+[[ -n "$CURRENT_VERSION" ]] || die "Could not parse version from $CARGO_TOML"
+
+# ── Compute next patch version ────────────────────────────────────────────────
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+[[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]] \
+  || die "Version '$CURRENT_VERSION' is not valid semver"
+NEXT_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+
+info "Current version : $CURRENT_VERSION"
+info "Next version    : $NEXT_VERSION"
+$EXECUTE || warn "DRY-RUN mode — pass --execute to apply changes"
+echo ""
+
+# ── Helper: sed in-place (portable across GNU and BSD/macOS) ─────────────────
+sedi() {
+  # $1 = sed expression, $2 = file
+  if sed --version 2>/dev/null | grep -q GNU; then
+    sed -i "$1" "$2"
+  else
+    sed -i '' "$1" "$2"
+  fi
+}
+
+apply() {
+  # apply <description> <file> <sed-expression>
+  local desc="$1" file="$2" expr="$3"
+  if grep -qE "${expr//\//\\/}" "$file" 2>/dev/null; then
+    if $EXECUTE; then
+      sedi "$expr" "$file"
+      ok "Updated  $file  ($desc)"
+    else
+      warn "Would update  $file  ($desc)"
+    fi
+  fi
+}
+
+# ── 1. Cargo.toml — workspace.package version ────────────────────────────────
+# Only replaces the version line that is inside [workspace.package]; the awk
+# approach above confirmed it exists. We use a targeted sed that matches the
+# exact quoted version string on a line starting with `version`.
+apply \
+  "[workspace.package] version" \
+  "$CARGO_TOML" \
+  "s/^\\(version[[:space:]]*=[[:space:]]*\\)\"${CURRENT_VERSION}\"/\\1\"${NEXT_VERSION}\"/"
+
+# ── 2. Any crate Cargo.toml with a standalone (non-workspace) version line ───
+# Workspace members use `version.workspace = true`, so this only fires for
+# crates that pin their own version explicitly.
+while IFS= read -r -d '' toml; do
+  [[ "$toml" == "$CARGO_TOML" ]] && continue  # already handled above
+  apply \
+    "standalone package version" \
+    "$toml" \
+    "s/^\\(version[[:space:]]*=[[:space:]]*\\)\"${CURRENT_VERSION}\"/\\1\"${NEXT_VERSION}\"/"
+done < <(find "$ROOT/crates" -name "Cargo.toml" -print0 2>/dev/null)
+
+# ── 3. CHANGELOG.md — promote [Unreleased] and insert fresh header ───────────
+CHANGELOG="$ROOT/CHANGELOG.md"
+TODAY=$(date -u +%Y-%m-%d)
+
+if [[ -f "$CHANGELOG" ]]; then
+  if $EXECUTE; then
+    # a) Rename ## [Unreleased] → ## [NEXT_VERSION] - DATE
+    sedi "s/^## \\[Unreleased\\]/## [${NEXT_VERSION}] - ${TODAY}/" "$CHANGELOG"
+
+    # b) Insert a blank [Unreleased] section above the new versioned entry
+    UNRELEASED_BLOCK="## [Unreleased]\n\n### Added\n\n### Changed\n\n### Fixed\n\n---\n"
+    sedi "/^## \\[${NEXT_VERSION}\\]/i\\
+${UNRELEASED_BLOCK}" "$CHANGELOG"
+
+    # c) Update the [Unreleased] diff link
+    sedi "s|compare/v${CURRENT_VERSION}\.\.\.HEAD|compare/v${NEXT_VERSION}...HEAD|g" "$CHANGELOG"
+
+    # d) Add the new version diff link (after the existing [Unreleased] link line)
+    NEW_LINK="[${NEXT_VERSION}]: https://github.com/d-oit/rust-2026-template/releases/tag/v${NEXT_VERSION}"
+    # Insert after the [Unreleased] link line if not already present
+    if ! grep -qF "[$NEXT_VERSION]:" "$CHANGELOG"; then
+      sedi "/^\[Unreleased\]:/a\\
+${NEW_LINK}" "$CHANGELOG"
+    fi
+
+    ok "Updated  $CHANGELOG  (promoted [Unreleased] → [$NEXT_VERSION])"
+  else
+    warn "Would update  $CHANGELOG  (promote [Unreleased] → [$NEXT_VERSION] - $TODAY)"
+  fi
+fi
+
+# ── 4. README.md — version badge and any explicit version strings ─────────────
+README="$ROOT/README.md"
+if [[ -f "$README" ]]; then
+  # Badge: rust-1.87%2B style URLs are toolchain badges, not crate version —
+  # skip those. Only replace bare version strings like "0.1.0".
+  apply \
+    "version string" \
+    "$README" \
+    "s/${CURRENT_VERSION}/${NEXT_VERSION}/g"
+fi
+
+# ── 5. Broad scan: *.md, *.yml, *.yaml, *.json outside target/ and .git/ ─────
+# Matches lines of the form:
+#   version: "0.1.0"   (YAML)
+#   version = "0.1.0"  (TOML / shell)
+#   "version": "0.1.0" (JSON)
+# Does NOT match lines like:
+#   tokio = { version = "1", ... }   (dependency specs use short versions)
+#   rust-version = "1.87"            (toolchain MSRV)
+VERSION_LINE_PATTERN="^[[:space:]]*(\"version\"|version)[[:space:]]*[:=][[:space:]]*\"${CURRENT_VERSION}\""
+
+while IFS= read -r -d '' file; do
+  # Skip files already handled above
+  [[ "$file" == "$CARGO_TOML" ]] && continue
+  [[ "$file" == "$CHANGELOG" ]] && continue
+  [[ "$file" == "$README" ]] && continue
+  # Skip workflow files that reference the version only in comments
+  if grep -qE "$VERSION_LINE_PATTERN" "$file" 2>/dev/null; then
+    apply \
+      "version line" \
+      "$file" \
+      "s/\\(^[[:space:]]*\\(\"version\"\\|version\\)[[:space:]]*[:=][[:space:]]*\\)\"${CURRENT_VERSION}\"/\\1\"${NEXT_VERSION}\"/"
+  fi
+done < <(find "$ROOT" \
+  \( -path "$ROOT/target" -o -path "$ROOT/.git" \) -prune \
+  -o \( -name "*.md" -o -name "*.yml" -o -name "*.yaml" -o -name "*.json" \) \
+  -print0)
+
+# ── 6. Regenerate Cargo.lock ──────────────────────────────────────────────────
+if $EXECUTE; then
+  info "Regenerating Cargo.lock..."
+  cargo update --workspace --quiet
+  ok "Cargo.lock updated"
+else
+  warn "Would run: cargo update --workspace  (to refresh Cargo.lock)"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+if $EXECUTE; then
+  ok "Version bumped: $CURRENT_VERSION → $NEXT_VERSION"
+else
+  info "Dry-run complete. Run with --execute to apply."
+fi

--- a/scripts/learn-labels.sh
+++ b/scripts/learn-labels.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# scripts/learn-labels.sh
+#
+# Self-learning label sync for d-oit/rust-2026-template.
+#
+# "Self-learning" means: mine the repo's own activity (closed issues, merged
+# PRs, commit messages, file paths touched) to discover label gaps, then
+# create only the labels that are genuinely missing.  No external AI API is
+# used — all signal comes from the GitHub API via `gh`.
+#
+# ── What it learns from ───────────────────────────────────────────────────────
+#
+#   1. COMMIT MESSAGES (last 90 days)
+#      Conventional-commit prefixes (feat, fix, docs, chore, perf, refactor,
+#      test, ci, build, style, revert) → ensure a matching label exists.
+#
+#   2. CLOSED ISSUES & MERGED PRs (last 90 days)
+#      Body text is scanned for recurring keywords (crate names, Rust concepts,
+#      workflow terms).  Any keyword that appears ≥ KEYWORD_THRESHOLD times
+#      and has no existing label becomes a candidate.
+#
+#   3. FILE PATHS TOUCHED IN RECENT PRs
+#      Paths like `.github/`, `scripts/`, `crates/<name>/`, `docs/` map to
+#      area labels (area: ci, area: scripts, area: <crate>, area: docs).
+#      Only created when the area has seen ≥ PATH_THRESHOLD PR touches.
+#
+#   4. EXISTING LABEL USAGE
+#      Labels that have never been applied to any issue or PR in the last
+#      90 days are flagged as stale (reported only — never auto-deleted).
+#
+# ── What it never does ────────────────────────────────────────────────────────
+#   - Delete labels (safe by design)
+#   - Modify labels that already exist (--force only on new ones)
+#   - Create labels whose name collides with an existing one (idempotent)
+#   - Require any external secret beyond GITHUB_TOKEN
+#
+# ── Output ────────────────────────────────────────────────────────────────────
+#   Writes a human-readable report to stdout and, when --execute is passed,
+#   calls `gh label create` for each net-new label.
+#   In CI the workflow captures stdout as the job summary.
+#
+# Usage:
+#   ./scripts/learn-labels.sh [--execute] [--days N] [--repo OWNER/REPO]
+#
+# Defaults:
+#   --days  90
+#   --repo  current repo detected via `gh repo view`
+
+set -euo pipefail
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+info()  { echo -e "${CYAN}[learn]${NC} $*"; }
+ok()    { echo -e "${GREEN}[learn]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[learn]${NC} $*"; }
+die()   { echo -e "${RED}[learn] ERROR:${NC} $*" >&2; exit 1; }
+header(){ echo -e "\n${BOLD}$*${NC}"; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+EXECUTE=false
+DAYS=90
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --execute)       EXECUTE=true ;;
+    --days)          DAYS="${2:?--days requires a value}"; shift ;;
+    --repo)          REPO="${2:?--repo requires a value}"; shift ;;
+    --help|-h)
+      grep '^#' "$0" | sed 's/^# \?//' | head -60
+      exit 0
+      ;;
+    *) die "Unknown argument: $1" ;;
+  esac
+  shift
+done
+
+# ── Dependency check ──────────────────────────────────────────────────────────
+for cmd in gh jq git; do
+  command -v "$cmd" &>/dev/null || die "$cmd is required but not installed."
+done
+
+# ── Resolve repo ──────────────────────────────────────────────────────────────
+if [[ -z "$REPO" ]]; then
+  REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) \
+    || die "Could not detect repo. Pass --repo OWNER/REPO explicitly."
+fi
+info "Repository : $REPO"
+info "Lookback   : $DAYS days"
+$EXECUTE || warn "DRY-RUN — pass --execute to create labels"
+
+SINCE=$(date -u -d "-${DAYS} days" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -v-"${DAYS}"d +%Y-%m-%dT%H:%M:%SZ)   # macOS fallback
+
+# ── Thresholds ────────────────────────────────────────────────────────────────
+KEYWORD_THRESHOLD=3   # keyword must appear in ≥ N issue/PR bodies
+PATH_THRESHOLD=2      # path area must appear in ≥ N PR file sets
+
+# ── 1. Fetch existing labels ──────────────────────────────────────────────────
+header "── Fetching existing labels"
+EXISTING_JSON=$(gh label list --repo "$REPO" --limit 200 --json name,color,description)
+EXISTING_NAMES=$(echo "$EXISTING_JSON" | jq -r '.[].name' | sort)
+EXISTING_COUNT=$(echo "$EXISTING_NAMES" | grep -c . || true)
+info "Found $EXISTING_COUNT existing labels"
+
+label_exists() { echo "$EXISTING_NAMES" | grep -qxF "$1"; }
+
+# ── 2. Collect recent closed issues + merged PRs ──────────────────────────────
+header "── Fetching recent issues and PRs (since $SINCE)"
+
+ISSUES_JSON=$(gh issue list \
+  --repo "$REPO" \
+  --state closed \
+  --limit 200 \
+  --json number,title,body,labels,closedAt \
+  2>/dev/null || echo "[]")
+
+PRS_JSON=$(gh pr list \
+  --repo "$REPO" \
+  --state merged \
+  --limit 200 \
+  --json number,title,body,labels,mergedAt,files \
+  2>/dev/null || echo "[]")
+
+ISSUE_COUNT=$(echo "$ISSUES_JSON" | jq 'length')
+PR_COUNT=$(echo "$PRS_JSON"    | jq 'length')
+info "Closed issues : $ISSUE_COUNT"
+info "Merged PRs    : $PR_COUNT"
+
+# ── 3. Learn from conventional-commit prefixes in recent commits ──────────────
+header "── Analysing commit messages"
+
+# Map conventional-commit type → label name + colour + description
+declare -A CC_LABEL CC_COLOR CC_DESC
+CC_LABEL=(
+  [feat]="feature"         [fix]="bug"              [docs]="documentation"
+  [chore]="chore"          [perf]="performance"     [refactor]="refactor"
+  [test]="tests"           [ci]="ci: improvement"   [build]="chore"
+  [style]="chore"          [revert]="revert"
+)
+CC_COLOR=(
+  [feat]="a2eeef"  [fix]="d73a4a"   [docs]="0075ca"  [chore]="fef2c0"
+  [perf]="5319e7"  [refactor]="0366d6" [test]="f4c542" [ci]="0075ca"
+  [build]="fef2c0" [style]="fef2c0" [revert]="e4e669"
+)
+CC_DESC=(
+  [feat]="New feature or enhancement"
+  [fix]="Something isn't working"
+  [docs]="Improvements or additions to documentation"
+  [chore]="Maintenance task, tooling update, cleanup"
+  [perf]="Performance-related improvement"
+  [refactor]="Code improvements without behaviour change"
+  [test]="Related to automated or manual tests"
+  [ci]="CI pipeline improvement or speed-up"
+  [build]="Build system or dependency change"
+  [style]="Code style or formatting change"
+  [revert]="Reverts a previous commit"
+)
+
+COMMIT_TYPES=()
+if git -C . log --since="$SINCE" --format="%s" 2>/dev/null | \
+    grep -oP '^(feat|fix|docs|chore|perf|refactor|test|ci|build|style|revert)(?:\([^)]+\))?' | \
+    sed 's/(.*//' | sort -u > /tmp/ll_cc_types.txt 2>/dev/null; then
+  while IFS= read -r cc_type; do
+    [[ -n "$cc_type" ]] && COMMIT_TYPES+=("$cc_type")
+  done < /tmp/ll_cc_types.txt
+fi
+info "Conventional-commit types found: ${COMMIT_TYPES[*]:-none}"
+
+# ── 4. Learn from issue/PR body keywords ─────────────────────────────────────
+header "── Mining issue and PR bodies for recurring keywords"
+
+# Combine all titles + bodies into one stream for keyword frequency analysis
+ALL_TEXT=$(
+  echo "$ISSUES_JSON" | jq -r '.[] | "\(.title) \(.body // "")"'
+  echo "$PRS_JSON"    | jq -r '.[] | "\(.title) \(.body // "")"'
+)
+
+# Keyword → candidate label mapping
+# Format: "keyword|label-name|color|description"
+# Keywords are matched case-insensitively as whole words.
+KEYWORD_MAP=(
+  "clippy|rust: clippy|f9d0c4|Clippy lint warning or fix"
+  "unsafe|rust: unsafe|ee0701|Involves unsafe Rust code — needs extra scrutiny"
+  "async|rust: async|6f42c1|Async / Tokio runtime concern"
+  "tokio|rust: async|6f42c1|Async / Tokio runtime concern"
+  "msrv|rust: msrv|c5def5|Minimum Supported Rust Version concern"
+  "edition|rust: edition|bfd4f2|Rust edition migration or compatibility"
+  "no.std|rust: no-std|e4e669|no_std compatibility"
+  "soundness|rust: soundness|b60205|Soundness or undefined behaviour concern"
+  "panic|rust: soundness|b60205|Soundness or undefined behaviour concern"
+  "security|security|b60205|Security-related issue or vulnerability"
+  "vulnerability|security|b60205|Security-related issue or vulnerability"
+  "audit|security|b60205|Security-related issue or vulnerability"
+  "performance|performance|5319e7|Performance-related improvement"
+  "benchmark|performance|5319e7|Performance-related improvement"
+  "flaky|ci: flaky|fbca04|Intermittently failing CI job"
+  "intermittent|ci: flaky|fbca04|Intermittently failing CI job"
+  "timeout|ci: flaky|fbca04|Intermittently failing CI job"
+  "breaking|release: breaking|b60205|Contains a breaking API change"
+  "breaking.change|release: breaking|b60205|Contains a breaking API change"
+  "semver|release: breaking|b60205|Contains a breaking API change"
+  "wasm|platform: wasm|c2e0c6|WebAssembly target concern"
+  "windows|platform: windows|0075ca|Windows-specific issue"
+  "macos|platform: macos|0075ca|macOS-specific issue"
+  "linux|platform: linux|0075ca|Linux-specific issue"
+  "docker|platform: docker|0075ca|Docker or container concern"
+  "memory|rust: perf|5319e7|Rust-specific performance optimisation"
+  "allocation|rust: perf|5319e7|Rust-specific performance optimisation"
+  "deadlock|rust: async|6f42c1|Async / Tokio runtime concern"
+  "race.condition|rust: soundness|b60205|Soundness or undefined behaviour concern"
+  "documentation|documentation|0075ca|Improvements or additions to documentation"
+  "readme|documentation|0075ca|Improvements or additions to documentation"
+  "changelog|documentation|0075ca|Improvements or additions to documentation"
+  "refactor|refactor|0366d6|Code improvements without behaviour change"
+  "cleanup|chore|fef2c0|Maintenance task, tooling update, cleanup"
+  "dependency|deps|cfd3d7|Dependency updates or changes"
+  "upgrade|deps|cfd3d7|Dependency updates or changes"
+  "bump|deps|cfd3d7|Dependency updates or changes"
+)
+
+# Count keyword occurrences
+declare -A KW_COUNT
+for entry in "${KEYWORD_MAP[@]}"; do
+  kw=$(echo "$entry" | cut -d'|' -f1)
+  count=$(echo "$ALL_TEXT" | grep -ciE "\b${kw}\b" 2>/dev/null || echo 0)
+  KW_COUNT["$kw"]=$count
+done
+
+# ── 5. Learn from file paths touched in recent PRs ───────────────────────────
+header "── Analysing file paths touched in recent PRs"
+
+declare -A PATH_COUNT
+while IFS= read -r path_entry; do
+  [[ -z "$path_entry" ]] && continue
+  # Map path prefixes to area labels
+  case "$path_entry" in
+    .github/*)   PATH_COUNT["area: ci"]=$(( ${PATH_COUNT["area: ci"]:-0} + 1 )) ;;
+    scripts/*)   PATH_COUNT["area: scripts"]=$(( ${PATH_COUNT["area: scripts"]:-0} + 1 )) ;;
+    docs/*)      PATH_COUNT["area: docs"]=$(( ${PATH_COUNT["area: docs"]:-0} + 1 )) ;;
+    plans/*)     PATH_COUNT["area: docs"]=$(( ${PATH_COUNT["area: docs"]:-0} + 1 )) ;;
+    src/*)       PATH_COUNT["area: core"]=$(( ${PATH_COUNT["area: core"]:-0} + 1 )) ;;
+    crates/*)
+      # Extract crate name: crates/<name>/...
+      crate=$(echo "$path_entry" | cut -d'/' -f2)
+      [[ -n "$crate" ]] && \
+        PATH_COUNT["area: $crate"]=$(( ${PATH_COUNT["area: $crate"]:-0} + 1 ))
+      ;;
+  esac
+done < <(echo "$PRS_JSON" | jq -r '.[] | .files[]?.path // empty' 2>/dev/null || true)
+
+# ── 6. Check label usage (stale detection) ───────────────────────────────────
+header "── Checking label usage in the last $DAYS days"
+
+USED_LABELS=$(
+  { echo "$ISSUES_JSON"; echo "$PRS_JSON"; } \
+  | jq -r '.[] | .labels[]?.name' 2>/dev/null \
+  | sort -u
+)
+
+STALE_LABELS=()
+while IFS= read -r lname; do
+  [[ -z "$lname" ]] && continue
+  if ! echo "$USED_LABELS" | grep -qxF "$lname"; then
+    STALE_LABELS+=("$lname")
+  fi
+done <<< "$EXISTING_NAMES"
+
+# ── 7. Build the candidate list ───────────────────────────────────────────────
+header "── Computing net-new label candidates"
+
+declare -A CANDIDATES  # name → "color|description"
+
+# From conventional commits
+for cc_type in "${COMMIT_TYPES[@]}"; do
+  lname="${CC_LABEL[$cc_type]:-}"
+  [[ -z "$lname" ]] && continue
+  label_exists "$lname" && continue
+  CANDIDATES["$lname"]="${CC_COLOR[$cc_type]:-cccccc}|${CC_DESC[$cc_type]:-Conventional commit type: $cc_type}"
+done
+
+# From keyword mining
+for entry in "${KEYWORD_MAP[@]}"; do
+  kw=$(echo "$entry"   | cut -d'|' -f1)
+  lname=$(echo "$entry" | cut -d'|' -f2)
+  color=$(echo "$entry" | cut -d'|' -f3)
+  desc=$(echo "$entry"  | cut -d'|' -f4)
+  count=${KW_COUNT["$kw"]:-0}
+  [[ "$count" -lt "$KEYWORD_THRESHOLD" ]] && continue
+  label_exists "$lname" && continue
+  CANDIDATES["$lname"]="${color}|${desc} (seen ${count}×)"
+done
+
+# From file path analysis
+for area_label in "${!PATH_COUNT[@]}"; do
+  count=${PATH_COUNT["$area_label"]}
+  [[ "$count" -lt "$PATH_THRESHOLD" ]] && continue
+  label_exists "$area_label" && continue
+  CANDIDATES["$area_label"]="bfd4f2|Files in this area were touched in ${count} recent PRs"
+done
+
+# ── 8. Report ─────────────────────────────────────────────────────────────────
+header "── Results"
+
+CANDIDATE_COUNT=${#CANDIDATES[@]}
+
+if [[ "$CANDIDATE_COUNT" -eq 0 ]]; then
+  ok "No new labels needed — existing set covers all observed activity."
+else
+  echo ""
+  printf "%-35s %-8s %s\n" "LABEL" "COLOR" "DESCRIPTION"
+  printf "%-35s %-8s %s\n" "-----" "-----" "-----------"
+  for lname in $(echo "${!CANDIDATES[@]}" | tr ' ' '\n' | sort); do
+    color=$(echo "${CANDIDATES[$lname]}" | cut -d'|' -f1)
+    desc=$(echo "${CANDIDATES[$lname]}"  | cut -d'|' -f2-)
+    printf "%-35s #%-7s %s\n" "$lname" "$color" "$desc"
+  done
+fi
+
+if [[ "${#STALE_LABELS[@]}" -gt 0 ]]; then
+  echo ""
+  warn "Labels unused in the last $DAYS days (not deleted — review manually):"
+  for sl in "${STALE_LABELS[@]}"; do
+    echo "    $sl"
+  done
+fi
+
+# ── 9. Apply ──────────────────────────────────────────────────────────────────
+CREATED=0
+SKIPPED=0
+
+if [[ "$CANDIDATE_COUNT" -gt 0 ]]; then
+  echo ""
+  if $EXECUTE; then
+    header "── Creating $CANDIDATE_COUNT new label(s)"
+    for lname in $(echo "${!CANDIDATES[@]}" | tr ' ' '\n' | sort); do
+      color=$(echo "${CANDIDATES[$lname]}" | cut -d'|' -f1)
+      desc=$(echo "${CANDIDATES[$lname]}"  | cut -d'|' -f2-)
+      # Strip the "(seen N×)" annotation from the description before creating
+      clean_desc=$(echo "$desc" | sed 's/ (seen [0-9]*×)//')
+      if gh label create "$lname" \
+          --repo "$REPO" \
+          --color "$color" \
+          --description "$clean_desc" \
+          --force 2>/dev/null; then
+        ok "Created: $lname"
+        (( CREATED++ )) || true
+      else
+        warn "Failed:  $lname"
+        (( SKIPPED++ )) || true
+      fi
+    done
+  else
+    warn "DRY-RUN: would create $CANDIDATE_COUNT label(s). Pass --execute to apply."
+    SKIPPED=$CANDIDATE_COUNT
+  fi
+fi
+
+# ── 10. Machine-readable summary for CI ──────────────────────────────────────
+echo ""
+echo "SUMMARY: existing=${EXISTING_COUNT} candidates=${CANDIDATE_COUNT} created=${CREATED} skipped=${SKIPPED} stale=${#STALE_LABELS[@]}"
+
+# Emit GitHub Actions outputs when running in CI
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "existing_count=${EXISTING_COUNT}"   >> "$GITHUB_OUTPUT"
+  echo "candidate_count=${CANDIDATE_COUNT}" >> "$GITHUB_OUTPUT"
+  echo "created_count=${CREATED}"           >> "$GITHUB_OUTPUT"
+  echo "stale_count=${#STALE_LABELS[@]}"    >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/setup-github-labels.sh
+++ b/scripts/setup-github-labels.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/setup-github-labels.sh
+#
+# Creates the full label set for d-oit/rust-2026-template.
+# Includes all standard labels plus Rust-specific and release automation labels.
+#
+# Usage:
+#   ./scripts/setup-github-labels.sh
+#
+# Requirements:
+#   gh  — GitHub CLI (https://cli.github.com/)
+#   jq  — JSON processor (https://stedolan.github.io/jq/)
+#
+# The script will prompt before deleting existing labels.
+# All `gh label create` calls use --force so re-running is safe (idempotent).
+
+set -euo pipefail
+
+# ── Dependency check ──────────────────────────────────────────────────────────
+if ! command -v gh &>/dev/null || ! command -v jq &>/dev/null; then
+  echo "Error: GitHub CLI (gh) and jq are required."
+  echo "  Install gh:  https://cli.github.com/"
+  echo "  Install jq:  https://stedolan.github.io/jq/"
+  exit 1
+fi
+
+# ── Optional: delete all existing labels first ────────────────────────────────
+read -rp "Delete ALL existing labels before creating? (y/N) " confirm
+
+if [[ "$confirm" =~ ^[Yy](es)?$ ]]; then
+  echo "Deleting all existing labels..."
+  label_names=$(gh label list --limit 200 --json name --jq '.[].name')
+  if [[ -n "$label_names" ]]; then
+    while IFS= read -r label; do
+      [[ -n "$label" ]] || continue
+      echo "  Deleting: $label"
+      gh label delete "$label" --yes 2>/dev/null || echo "  Failed to delete: $label"
+    done <<< "$label_names"
+    echo "Deletion complete."
+  else
+    echo "No existing labels found."
+  fi
+else
+  echo "Skipping deletion — existing labels will be kept."
+fi
+
+echo ""
+echo "Creating labels..."
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+label() {
+  # label <name> <color-hex-no-hash> <description>
+  gh label create "$1" --color "$2" --description "$3" --force
+  echo "  ✓ $1"
+}
+
+# ── Type labels ───────────────────────────────────────────────────────────────
+label "bug"           "d73a4a" "Something isn't working"
+label "feature"       "a2eeef" "New feature or enhancement request"
+label "documentation" "0075ca" "Improvements or additions to documentation"
+label "question"      "d876e3" "Further information is requested"
+label "discussion"    "8b949e" "Open-ended conversation or design discussion"
+label "refactor"      "0366d6" "Code improvements without behaviour change"
+label "performance"   "5319e7" "Performance-related improvement"
+label "tests"         "f4c542" "Related to automated or manual tests"
+label "chore"         "fef2c0" "Maintenance task, tooling update, cleanup"
+label "deps"          "cfd3d7" "Dependency updates or changes"
+
+# ── Priority labels ───────────────────────────────────────────────────────────
+label "priority: high"   "b60205" "Critical, needs immediate attention"
+label "priority: medium" "fbca04" "Important but not urgent"
+label "priority: low"    "0e8a16" "Low urgency, can wait"
+
+# ── Status labels ─────────────────────────────────────────────────────────────
+label "status: in progress"   "1d76db" "Currently being worked on"
+label "status: needs review"  "dbab09" "Waiting for review"
+label "status: needs triage"  "e4e669" "Needs categorisation or investigation"
+label "status: blocked"       "e4e669" "Cannot proceed due to a dependency or blocker"
+label "status: duplicate"     "cccccc" "Duplicate of another issue or PR"
+label "status: wontfix"       "ffffff" "Not planned to be fixed or implemented"
+
+# ── Security label ────────────────────────────────────────────────────────────
+label "security" "b60205" "Security-related issue or vulnerability"
+
+# ── Rust-specific labels ──────────────────────────────────────────────────────
+label "rust: unsafe"      "ee0701" "Involves unsafe Rust code — needs extra scrutiny"
+label "rust: async"       "6f42c1" "Async / Tokio runtime concern"
+label "rust: clippy"      "f9d0c4" "Clippy lint warning or fix"
+label "rust: msrv"        "c5def5" "Minimum Supported Rust Version concern"
+label "rust: edition"     "bfd4f2" "Rust edition migration or compatibility"
+label "rust: no-std"      "e4e669" "no_std compatibility"
+label "rust: perf"        "5319e7" "Rust-specific performance optimisation"
+label "rust: soundness"   "b60205" "Soundness or undefined behaviour concern"
+
+# ── CI / CD labels ────────────────────────────────────────────────────────────
+label "ci: failing"       "d73a4a" "CI pipeline is broken"
+label "ci: flaky"         "fbca04" "Intermittently failing CI job"
+label "ci: improvement"   "0075ca" "CI pipeline improvement or speed-up"
+
+# ── Release automation labels ─────────────────────────────────────────────────
+# `release:patch` is the trigger for .github/workflows/patch-release-on-label.yml
+label "release:patch"     "0e8a16" "Trigger: bump patch version on merge (automated)"
+label "release: breaking" "b60205" "Contains a breaking API change"
+label "release: skip"     "cccccc" "Exclude this PR from release notes"
+
+echo ""
+echo "All labels created successfully."


### PR DESCRIPTION
## Summary

This PR covers everything from the session — documentation updates across the whole codebase, a one-shot label bootstrap script, a self-learning monthly label sync, and a patch release automation triggered by a PR label.

---

## Changes

### 1. Documentation — sync all markdown to the actual codebase

All `.md` files updated to reflect the real repository state (two crates, three scripts, nine agent skills, correct directory tree).

| File | What changed |
|---|---|
| `README.md` | Two-crate workspace, all 9 skills, full directory tree, cargo aliases, scripts table |
| `QUICKSTART.md` | `sample-app` run commands, `--fix` flag, `release-manager.sh` in the "What You Get" table |
| `agents-docs/structure.md` | Full tree: both crates, all 9 skill dirs, `docs/`, `src/`, `plans/`, `.envrc`, `flake.nix` |
| `agents-docs/commands.md` | Cargo aliases table, per-crate nextest commands, corrected CI parity table, release workflow steps |
| `.agents/SKILLS.md` | Added 5 missing skills: `crates-io-name-check`, `anti-ai-slop`, `privacy-first`, `skill-creator`, `skill-evaluator` |
| `crates/example-crate/README.md` | Documents `greet()` API and rename workflow |
| `crates/sample-app/README.md` | Documents all deps, CLI flags, config file format, 1 MB size guard |
| `plans/GOAP_STATE.md` | Updated state for both crates, doc tests, all recent changes |
| `plans/adr/0001-rust-edition-and-toolchain.md` | Noted toolchain bump to 1.87, added upgrade guidance |
| `CHANGELOG.md` | Replaced placeholder unreleased section with accurate entries; fixed diff links |

---

### 2. Label bootstrap — `scripts/setup-github-labels.sh`

One-shot script that creates 35 labels across six groups. Run once per repo.

```bash
./scripts/setup-github-labels.sh
```

| Group | Labels |
|---|---|
| Type | `bug`, `feature`, `documentation`, `question`, `discussion`, `refactor`, `performance`, `tests`, `chore`, `deps` |
| Priority | `priority: high/medium/low` |
| Status | `status: in progress`, `needs review`, `needs triage`, `blocked`, `duplicate`, `wontfix` |
| Security | `security` |
| Rust-specific | `rust: unsafe`, `async`, `clippy`, `msrv`, `edition`, `no-std`, `perf`, `soundness` |
| CI/CD | `ci: failing`, `ci: flaky`, `ci: improvement` |
| Release | `release:patch` *(workflow trigger)*, `release: breaking`, `release: skip` |

All `gh label create` calls use `--force` — re-running is safe.

---

### 3. Self-learning label sync — `scripts/learn-labels.sh` + `.github/workflows/sync-labels.yml`

Mines the repo's own activity every month to discover and create missing labels. No external AI API — all signal comes from the GitHub API.

**Signal sources:**

| Source | What it produces |
|---|---|
| Conventional-commit prefixes in `git log` | Ensures a label exists for every `feat:`, `fix:`, `ci:`, etc. type actually used |
| Keyword frequency in closed issues + merged PR bodies | Labels like `rust: clippy`, `security`, `platform: wasm` created when a keyword appears ≥ 3 times |
| File paths touched in recent PRs | `area: ci`, `area: scripts`, `area: <crate>` labels when a path area appears in ≥ 2 PRs |
| Label usage frequency | Labels unused in the lookback window flagged as stale (reported only — never deleted) |

**Workflow triggers:**
- `schedule`: 1st of every month at 08:00 UTC
- `workflow_dispatch`: manual, with `days` (lookback window) and `dry_run` (checkbox) inputs

**Safety:** labels are only ever created, never deleted. `--force` makes every run idempotent. Minimum permissions: `issues: write` + `contents: read`.

---

### 4. Patch release automation — `scripts/bump-version.sh` + `.github/workflows/patch-release-on-label.yml`

Bumps the patch version across the entire codebase when a PR receives the `release:patch` label, then commits the changes back to the PR branch.

**Canonical version source:** `[workspace.package] version` in `Cargo.toml`

**Files updated by `bump-version.sh`:**
- `Cargo.toml` — `[workspace.package]` version
- `crates/*/Cargo.toml` — any crate with a standalone version line
- `Cargo.lock` — regenerated via `cargo update --workspace`
- `CHANGELOG.md` — promotes `[Unreleased]` → `[X.Y.Z]`, inserts fresh `[Unreleased]` header, updates diff links
- `README.md` — explicit version strings
- `*.md / *.yml / *.yaml / *.json` — lines matching `version = "OLD"` exactly (dependency specs left untouched)

**Loop prevention:**
- `github.actor != 'github-actions[bot]'` — bot's own label event is ignored
- `[skip ci]` in the commit message — suppresses CI re-runs
- `concurrency: cancel-in-progress: true` — one bump per PR at a time

---

## Checklist

- [x] `bash -n` syntax check passes on all three scripts
- [x] YAML validated (`yaml.safe_load`) on both workflows
- [x] `bump-version.sh` dry-run tested: correctly reads `0.1.0`, computes `0.1.1`, identifies changed files
- [x] `learn-labels.sh` dry-run tested locally
- [x] No secrets required beyond `GITHUB_TOKEN`
- [x] No labels deleted by any automation
