### PR TITLE
Sentinel: [improvement] Fix log injection via config path

### DIFF
--- a/crates/sample-app/src/main.rs
+++ b/crates/sample-app/src/main.rs
@@ -113,15 +113,22 @@ fn load_config(config_path: Option<PathBuf>) -> Result<Config> {
     const MAX_APP_NAME_LEN: usize = 64;
 
     if let Some(path) = config_path {
-        info!("Loading config from: {}", path.display());
+        // Security: Sanitize path for logging and errors to prevent log injection.
+        // Replace control characters (like newlines) with '?' to keep logs safe.
+        let path_str = path.to_string_lossy();
+        let sanitized_path: String = path_str
+            .chars()
+            .map(|c| if c.is_control() { '?' } else { c })
+            .collect();
+
+        info!("Loading config from: {sanitized_path}");
 
         let file = std::fs::File::open(&path)?;
         let metadata = file.metadata()?;
 
         if !metadata.is_file() {
             return Err(AppError::Config(format!(
-                "Config path is not a regular file: {}",
-                path.display()
+                "Config path is not a regular file: {sanitized_path}"
             )));
         }
 


### PR DESCRIPTION
Sanitized the configuration file path by replacing control characters with '?' before logging it or including it in error messages. This prevents log injection (CWE-117) where an attacker could spoof log entries by providing a path containing newlines.

Severity: Medium
Impact: Prevents log spoofing and injection attacks via malicious configuration file paths.
Verification: Verified with a reproduction script that demonstrated newline replacement in logs and error messages.

---
*PR created automatically by Jules for task [17438896754618224083](https://jules.google.com/task/17438896754618224083) started by @d-oit*