### PR TITLE
chore(ci): skip commitlint for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           globs: "**/*.md"
       - name: Commitlint
+        if: github.actor != 'dependabot[bot]'
         uses: wagoid/commitlint-github-action@v6
 
   # ───────────────────────────────────────────────────


### PR DESCRIPTION
This PR modifies the CI workflow to skip the `commitlint` check for PRs authored by Dependabot. This prevents autogenerated commit messages with long body lines from blocking CI success. Human-authored commits remain subject to standard validation.

Fixes #47

---
*PR created automatically by Jules for task [14549348462670884787](https://jules.google.com/task/14549348462670884787) started by @d-oit*