### PR TITLE
Update AGENTS.md as canonical instruction file

### DIFF
--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -1,5 +1,7 @@
 # AI Agent Rules for Rust Workspace
 
+@AGENTS.md
+
 ## General Principles
 
 - Prefer `anyhow` for applications and `thiserror` for library error handling.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,10 @@ rust-2026-template/
 
 | Operation | Skill | Script/CLI |
 |-----------|-------|------------|
-| Build | `build-rust` | `./scripts/build-rust.sh` |
-| Format/Lint | `code-quality` | `./scripts/code-quality.sh` |
-| Quality Gates | `code-quality` | `./scripts/quality-gates.sh` |
-| Tests | `test-runner` | `cargo nextest run --all` |
+| Build | `build-rust` | `cargo build --workspace` |
+| Format/Lint | `lint-rust` | `./scripts/code-quality.sh` |
+| Quality Gates | `lint-rust` | `./scripts/quality-gates.sh` |
+| Tests | `test-rust` | `cargo nextest run --all` |
 
 **Before task tool:** 1) Skill in `.agents/skills/`? → Use it 2) Script in `scripts/`? → Use it 3) High-frequency? → Skill+CLI 4) Complex multi-agent? → task tool
 
@@ -96,3 +96,8 @@ rust-2026-template/
 | Workflow | `agents-docs/workflow.md` |
 | Architecture | `plans/adr/` |
 | Skills | `.agents/skills/` |
+
+---
+
+> **Canonical Source of Truth**: This file is the primary instruction set for all AI agents.
+> Agent-specific files (CLAUDE.md, GEMINI.md, QWEN.md) reference this file.

--- a/agents-docs/workflow.md
+++ b/agents-docs/workflow.md
@@ -26,11 +26,11 @@
 
 | Operation | Skill | Script/CLI |
 |-----------|-------|------------|
-| Build | `build-rust` | `./scripts/build-rust.sh` |
-| Format/Lint | `code-quality` | `./scripts/code-quality.sh` |
-| Quality Gates | `code-quality` | `./scripts/quality-gates.sh` |
+| Build | `build-rust` | `cargo build --workspace` |
+| Format/Lint | `lint-rust` | `./scripts/code-quality.sh` |
+| Quality Gates | `lint-rust` | `./scripts/quality-gates.sh` |
 | CI Issues | `github-workflows` | `gh workflow list` |
-| Tests | `test-runner` | `cargo nextest run --all` |
+| Tests | `test-rust` | `cargo nextest run --all` |
 | Debug | `debug-troubleshoot` | `RUST_LOG=debug cargo nextest run` |
 
 **Before using task tool:**


### PR DESCRIPTION
This PR updates AGENTS.md to act as the single canonical source of truth for agent instructions in this repository. 

Key changes:
- Corrected skill names: replaced `code-quality` with `lint-rust` and `test-runner` with `test-rust` to match `.agents/skills/`.
- Fixed command mappings: updated build operation to use `cargo build --workspace` as `./scripts/build-rust.sh` does not exist.
- Synchronized `agents-docs/workflow.md` to reflect these same skill and command updates.
- Added an explicit note in `AGENTS.md` about its role as the primary instruction set.
- Linked `.cursor/rules.md` to `AGENTS.md` via the `@AGENTS.md` reference pattern used by other agent entrypoints (CLAUDE.md, GEMINI.md, etc.).

These updates ensure that all agents (Claude, Gemini, Qwen, Cursor) receive consistent and up-to-date guidance based on the actual repository structure and available scripts.

Fixes #51

---
*PR created automatically by Jules for task [12853597543300932370](https://jules.google.com/task/12853597543300932370) started by @d-oit*