### PR TITLE
docs: refresh human and agent documentation structure

### DIFF
--- a/.claude/rules.md
+++ b/.claude/rules.md
@@ -1,32 +1,3 @@
-# AI Agent Rules for Rust Workspace
+# Claude Rules
 
-## General Principles
-
-- Prefer `anyhow` for applications and `thiserror` for library error handling.
-- Use `tokio` for asynchronous programming.
-- Follow `clippy` pedantic rules and maintain a zero-warning policy.
-- Adhere to the workspace/crate structure (`crates/` for members).
-
-## Error Handling
-
-- Use `thiserror` for defining custom error types in libraries (`crates/example-crate`).
-- Use `anyhow` in binaries (`crates/sample-app`) for high-level error context and management.
-- Avoid `unwrap()` and `expect()` in library code.
-
-## Asynchronous Programming
-
-- Use `#[tokio::main]` for entry points.
-- Prefer `tokio` primitives for synchronization and I/O.
-- Be mindful of blocking operations in async contexts; use `spawn_blocking` when necessary.
-
-## Code Quality
-
-- All code must be formatted with `cargo fmt`.
-- Address all Clippy suggestions.
-- Write unit tests for new functionality.
-- Use `proptest` for property-based testing of pure functions.
-
-## Workspace Conventions
-
-- New crates should be added to the `crates/` directory.
-- Update the root `Cargo.toml` when adding workspace members.
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.

--- a/.cursor/rules.md
+++ b/.cursor/rules.md
@@ -1,34 +1,10 @@
-# AI Agent Rules for Rust Workspace
+# Cursor Rules
 
-@AGENTS.md
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.
 
-## General Principles
+## Cursor-Specific Principles
 
 - Prefer `anyhow` for applications and `thiserror` for library error handling.
 - Use `tokio` for asynchronous programming.
 - Follow `clippy` pedantic rules and maintain a zero-warning policy.
 - Adhere to the workspace/crate structure (`crates/` for members).
-
-## Error Handling
-
-- Use `thiserror` for defining custom error types in libraries (`crates/example-crate`).
-- Use `anyhow` in binaries (`crates/sample-app`) for high-level error context and management.
-- Avoid `unwrap()` and `expect()` in library code.
-
-## Asynchronous Programming
-
-- Use `#[tokio::main]` for entry points.
-- Prefer `tokio` primitives for synchronization and I/O.
-- Be mindful of blocking operations in async contexts; use `spawn_blocking` when necessary.
-
-## Code Quality
-
-- All code must be formatted with `cargo fmt`.
-- Address all Clippy suggestions.
-- Write unit tests for new functionality.
-- Use `proptest` for property-based testing of pure functions.
-
-## Workspace Conventions
-
-- New crates should be added to the `crates/` directory.
-- Update the root `Cargo.toml` when adding workspace members.

--- a/.gemini/rules.md
+++ b/.gemini/rules.md
@@ -1,32 +1,3 @@
-# AI Agent Rules for Rust Workspace
+# Gemini Rules
 
-## General Principles
-
-- Prefer `anyhow` for applications and `thiserror` for library error handling.
-- Use `tokio` for asynchronous programming.
-- Follow `clippy` pedantic rules and maintain a zero-warning policy.
-- Adhere to the workspace/crate structure (`crates/` for members).
-
-## Error Handling
-
-- Use `thiserror` for defining custom error types in libraries (`crates/example-crate`).
-- Use `anyhow` in binaries (`crates/sample-app`) for high-level error context and management.
-- Avoid `unwrap()` and `expect()` in library code.
-
-## Asynchronous Programming
-
-- Use `#[tokio::main]` for entry points.
-- Prefer `tokio` primitives for synchronization and I/O.
-- Be mindful of blocking operations in async contexts; use `spawn_blocking` when necessary.
-
-## Code Quality
-
-- All code must be formatted with `cargo fmt`.
-- Address all Clippy suggestions.
-- Write unit tests for new functionality.
-- Use `proptest` for property-based testing of pure functions.
-
-## Workspace Conventions
-
-- New crates should be added to the `crates/` directory.
-- Update the root `Cargo.toml` when adding workspace members.
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,13 @@
 
 **Learning:** Recursive scans (like `grep -r`) in a Rust workspace are surprisingly expensive due to the `target/` directory, which often contains tens of thousands of build artifacts. Filtering results with `grep -v` after a full scan is a common anti-pattern that wastes significant I/O.
 **Action:** Always use `--exclude-dir=target` (and `.git`) in search commands to prevent the tool from even entering these directories. This can reduce scan times by 70% or more.
+
+## 2026-05-05 - [Documentation Architecture for Agent Performance]
+
+**Learning:** Mixing human-centric narrative with agent-specific technical instructions in a single README.md leads to "prompt spillover," where agents consume unnecessary tokens and may misinterpret conversational text as strict constraints.
+**Action:** Establish a clear separation: README.md for humans, AGENTS.md as the canonical technical source of truth for agents. Use thin wrappers in tool-specific files (CLAUDE.md, .cursor/rules.md, etc.) that point to AGENTS.md to minimize redundancy and prevent "prompt drift" across different AI assistants.
+
+## 2026-05-05 - [CI Rigidity in Documentation]
+
+**Learning:** Automated linting for documentation (markdownlint) and commit messages (commitlint) can block development if not accounted for in agent workflows. MD031 (blanks around fences) and body-max-line-length are common failure points.
+**Action:** Explicitly document CI-enforced documentation rules in AGENTS.md and conventions.md. Agents must verify documentation changes against local linting tools (npx markdownlint-cli2) and ensure commit bodies are properly wrapped to avoid build failures.

--- a/.opencode/rules/rust-rules.md
+++ b/.opencode/rules/rust-rules.md
@@ -1,32 +1,10 @@
-# AI Agent Rules for Rust Workspace
+# OpenCode Rules
 
-## General Principles
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.
+
+## Project Principles
 
 - Prefer `anyhow` for applications and `thiserror` for library error handling.
 - Use `tokio` for asynchronous programming.
 - Follow `clippy` pedantic rules and maintain a zero-warning policy.
 - Adhere to the workspace/crate structure (`crates/` for members).
-
-## Error Handling
-
-- Use `thiserror` for defining custom error types in libraries (`crates/example-crate`).
-- Use `anyhow` in binaries (`crates/sample-app`) for high-level error context and management.
-- Avoid `unwrap()` and `expect()` in library code.
-
-## Asynchronous Programming
-
-- Use `#[tokio::main]` for entry points.
-- Prefer `tokio` primitives for synchronization and I/O.
-- Be mindful of blocking operations in async contexts; use `spawn_blocking` when necessary.
-
-## Code Quality
-
-- All code must be formatted with `cargo fmt`.
-- Address all Clippy suggestions.
-- Write unit tests for new functionality.
-- Use `proptest` for property-based testing of pure functions.
-
-## Workspace Conventions
-
-- New crates should be added to the `crates/` directory.
-- Update the root `Cargo.toml` when adding workspace members.

--- a/.qwen/rules.md
+++ b/.qwen/rules.md
@@ -1,32 +1,3 @@
-# AI Agent Rules for Rust Workspace
+# Qwen Rules
 
-## General Principles
-
-- Prefer `anyhow` for applications and `thiserror` for library error handling.
-- Use `tokio` for asynchronous programming.
-- Follow `clippy` pedantic rules and maintain a zero-warning policy.
-- Adhere to the workspace/crate structure (`crates/` for members).
-
-## Error Handling
-
-- Use `thiserror` for defining custom error types in libraries (`crates/example-crate`).
-- Use `anyhow` in binaries (`crates/sample-app`) for high-level error context and management.
-- Avoid `unwrap()` and `expect()` in library code.
-
-## Asynchronous Programming
-
-- Use `#[tokio::main]` for entry points.
-- Prefer `tokio` primitives for synchronization and I/O.
-- Be mindful of blocking operations in async contexts; use `spawn_blocking` when necessary.
-
-## Code Quality
-
-- All code must be formatted with `cargo fmt`.
-- Address all Clippy suggestions.
-- Write unit tests for new functionality.
-- Use `proptest` for property-based testing of pure functions.
-
-## Workspace Conventions
-
-- New crates should be added to the `crates/` directory.
-- Update the root `Cargo.toml` when adding workspace members.
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.

--- a/.windsurf/rules.md
+++ b/.windsurf/rules.md
@@ -1,32 +1,3 @@
-# AI Agent Rules for Rust Workspace
+# Windsurf Rules
 
-## General Principles
-
-- Prefer `anyhow` for applications and `thiserror` for library error handling.
-- Use `tokio` for asynchronous programming.
-- Follow `clippy` pedantic rules and maintain a zero-warning policy.
-- Adhere to the workspace/crate structure (`crates/` for members).
-
-## Error Handling
-
-- Use `thiserror` for defining custom error types in libraries (`crates/example-crate`).
-- Use `anyhow` in binaries (`crates/sample-app`) for high-level error context and management.
-- Avoid `unwrap()` and `expect()` in library code.
-
-## Asynchronous Programming
-
-- Use `#[tokio::main]` for entry points.
-- Prefer `tokio` primitives for synchronization and I/O.
-- Be mindful of blocking operations in async contexts; use `spawn_blocking` when necessary.
-
-## Code Quality
-
-- All code must be formatted with `cargo fmt`.
-- Address all Clippy suggestions.
-- Write unit tests for new functionality.
-- Use `proptest` for property-based testing of pure functions.
-
-## Workspace Conventions
-
-- New crates should be added to the `crates/` directory.
-- Update the root `Cargo.toml` when adding workspace members.
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,103 +1,86 @@
 # Agent Coding Guidelines
 
-> **2026 Best Practice Rust Template** - All AI agents read this file first.
+> **Canonical Source of Truth**: This file is the primary instruction set for all AI agents.
+> Agent-specific files (CLAUDE.md, GEMINI.md, QWEN.md, .cursor/rules.md) are thin references only.
 
 ## Quick Reference
 
 | Task | Command |
 |------|----------|
 | Build | `cargo build --workspace` |
-| Quality | `./scripts/code-quality.sh fmt\|clippy\|audit\|check` |
-| Tests | `cargo nextest run --all` |
-| Quality Gates | `./scripts/quality-gates.sh` |
+| Format/Lint | `./scripts/code-quality.sh fmt\|clippy\|audit\|check\|fix` |
+| Tests | `cargo nextest run --workspace` |
+| Quality Gates | `./scripts/quality-gates.sh [--fix]` |
+| Release | `./scripts/release-manager.sh` |
 
 ## Project Structure
 
-```
-rust-2026-template/
-├── .agents/skills/      # AI agent skill definitions
-├── .cargo/config.toml   # Cargo linker + profile config
-├── .config/nextest.toml # nextest profiles
+```text
+.
+├── .agents/skills/      # AI agent skill definitions (runbooks)
+├── .cargo/config.toml   # Cargo linker + profile + aliases
+├── .config/nextest.toml # nextest profiles (default, ci)
 ├── .github/workflows/   # CI/CD GitHub Actions
-├── scripts/             # Dev helper scripts
+├── crates/              # Workspace crates (libraries and apps)
+├── scripts/             # Development and quality gate scripts
 ├── plans/adr/           # Architecture Decision Records
-├── AGENTS.md            # THIS FILE
-├── CLAUDE.md            # Claude: @AGENTS.md
-├── GEMINI.md            # Gemini: @AGENTS.md
+├── AGENTS.md            # THIS FILE (Primary guidance)
+├── CLAUDE.md            # Reference to AGENTS.md
+├── GEMINI.md            # Reference to AGENTS.md
 └── Cargo.toml           # Workspace manifest
 ```
 
-## Skill + CLI Pattern (CRITICAL)
+## Skill Inventory (`.agents/skills/`)
 
-**ALWAYS use Skill + CLI first** for high-frequency ops:
+Always prefer using the defined skills for their respective tasks:
 
-| Operation | Skill | Script/CLI |
-|-----------|-------|------------|
-| Build | `build-rust` | `cargo build --workspace` |
-| Format/Lint | `lint-rust` | `./scripts/code-quality.sh` |
-| Quality Gates | `lint-rust` | `./scripts/quality-gates.sh` |
-| Tests | `test-rust` | `cargo nextest run --all` |
+- `build-rust`: Build Rust projects correctly.
+- `lint-rust`: Run clippy, formatting, and quality gate checks.
+- `test-rust`: Run tests with `cargo-nextest`.
+- `release-rust`: Handle the release workflow.
+- `crates-io-name-check`: Verify crate name availability.
+- `anti-ai-slop`: Audit and fix generic AI-generated Rust patterns.
+- `privacy-first`: Prevent PII leaks in the codebase.
+- `skill-creator`: Create and optimize new agent skills.
+- `skill-evaluator`: Evaluate skill quality and structure.
 
-**Before task tool:** 1) Skill in `.agents/skills/`? → Use it 2) Script in `scripts/`? → Use it 3) High-frequency? → Skill+CLI 4) Complex multi-agent? → task tool
+## Core Directives
 
-## Token Efficiency
-
-1. **Glob** - File discovery (cheapest)
-2. **Grep** - Code search (cheap)
-3. **Read** - File inspection (medium)
-4. **Bash** - Shell commands (expensive - prefer scripts)
+1. **Prioritize Skills & Scripts**: 1) Check `.agents/skills/` 2) Check `scripts/` 3) Use standard CLI.
+2. **Zero Clippy Warnings**: All code must pass clippy without warnings. Fix issues rather than suppressing them.
+3. **Async First**: Use Tokio for async logic. Avoid blocking calls in async contexts.
+4. **Testing Excellence**:
+   - Use `proptest` for pure functions.
+   - Use `tokio::test` for async functions.
+   - Target 80%+ test coverage.
+5. **Code Quality**:
+   - Max 500 LOC per source file.
+   - Use `thiserror` for libraries and `anyhow` for binaries.
+   - No `unwrap()` in library code.
+6. **Documentation**: All public items must have `///` doc comments.
 
 ## Change Workflow
 
-1. Read existing code patterns
-2. Identify owner module + file
-3. Add/update tests first (TDD)
-4. `./scripts/code-quality.sh fmt`
-5. `cargo clippy --all -- -D warnings`
-6. `cargo nextest run -p <package>`
-7. `cargo nextest run --all`
-8. `./scripts/quality-gates.sh`
-9. Commit with conventional format
+1. **Explore**: Read existing patterns and identify the target module.
+2. **Test First**: Add or update tests before modifying implementation (TDD).
+3. **Format & Lint**: Run `./scripts/code-quality.sh fix` to apply formatting and fixes.
+4. **Verify**:
+   - `cargo nextest run -p <package>`
+   - `cargo nextest run --workspace`
+   - `./scripts/quality-gates.sh`
+5. **Commit**: Use Conventional Commits (`feat(scope): ...`, `fix(scope): ...`).
 
-## Required Checks Before Commit
+## Token Efficiency
 
-- [ ] `cargo fmt --all -- --check`
-- [ ] `cargo clippy --workspace --tests -- -D warnings`
-- [ ] `cargo build --workspace`
-- [ ] `cargo nextest run --all`
-- [ ] `./scripts/quality-gates.sh`
-
-## Code Conventions
-
-- **Max 500 LOC** per source file - split when exceeded
-- **Zero clippy warnings** - fix, never suppress
-- **Async everywhere** - Tokio, no blocking in async paths
-- **Testing** - Use `proptest` for pure functions; `tokio::test` for async
-- **Error handling** - `thiserror` lib, `anyhow` bin
-- **No `unwrap()`** in library code
-- **Doc comments** on all public items (`///`)
-- **Tests** - `#[tokio::test]` for async, AAA pattern
-
-## Core Invariants
-
-- **Async**: Tokio runtime, no blocking (use `spawn_blocking`)
-- **Clippy**: Zero warnings (`-D warnings`)
-- **Files**: ≤500 LOC
-- **Tests**: ≥80% coverage, `#[tokio::test]`
-- **Secrets**: Never hardcode, use `.env` or better env vars
+1. **Discovery**: Use `list_files` or globbing.
+2. **Search**: Use `grep` via bash.
+3. **Inspection**: Use `read_file` for targeted inspection.
+4. **Execution**: Prefer optimized scripts in `scripts/` over raw bash chains.
 
 ## Cross-References
 
-| Topic | Document |
-|-------|----------|
-| Commands | `agents-docs/commands.md` |
-| Structure | `agents-docs/structure.md` |
-| Conventions | `agents-docs/conventions.md` |
-| Workflow | `agents-docs/workflow.md` |
-| Architecture | `plans/adr/` |
-| Skills | `.agents/skills/` |
-
----
-
-> **Canonical Source of Truth**: This file is the primary instruction set for all AI agents.
-> Agent-specific files (CLAUDE.md, GEMINI.md, QWEN.md) reference this file.
+Detailed guidance is available in `agents-docs/`:
+- `agents-docs/commands.md`: Full CLI reference and aliases.
+- `agents-docs/conventions.md`: Coding standards and invariants.
+- `agents-docs/structure.md`: Deep dive into project layout.
+- `agents-docs/workflow.md`: Step-by-step development process.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,16 @@ Detailed guidance is available in `agents-docs/`:
 - `agents-docs/conventions.md`: Coding standards and invariants.
 - `agents-docs/structure.md`: Deep dive into project layout.
 - `agents-docs/workflow.md`: Step-by-step development process.
+
+## CI & Linting Notes (CRITICAL)
+
+1. **Commit Messages**: Body lines MUST NOT exceed 100 characters (enforced by commitlint).
+2. **Markdown**: Fenced code blocks MUST be surrounded by blank lines (MD031).
+
+## Linting Verification
+
+Run before commit:
+
+```bash
+npx markdownlint-cli2 README.md AGENTS.md CLAUDE.md GEMINI.md QWEN.md .cursor/rules.md .claude/rules.md .gemini/rules.md .qwen/rules.md .windsurf/rules.md agents-docs/*.md
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,10 @@
-@AGENTS.md
+# Claude Code Instructions
 
-<!-- Claude Code reads AGENTS.md directly via @-reference above.
-     Add Claude-specific overrides below if needed. -->
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.
 
 ## Claude-Specific Notes
 
 - Use `TodoWrite` tool to track task progress
 - Prefer `Read` tool over `Bash cat` for file inspection
-- Use `Bash` with `cargo nextest run -p <crate>` for targeted tests
 - Always run `./scripts/quality-gates.sh` before marking a task complete
 - For WSL2: watch for file watcher issues - check `.vscode/settings.json`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,12 +1,9 @@
-@AGENTS.md
+# Gemini CLI Instructions
 
-<!-- Gemini CLI reads AGENTS.md directly via @-reference above.
-     Add Gemini-specific overrides below if needed. -->
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.
 
 ## Gemini-Specific Notes
 
 - Use `google_web_search` for researching Rust crates and ecosystem updates
-- Prefer reading multiple files with parallel `ReadFile` calls
 - Always verify with `cargo check --workspace` before applying large refactors
-- For long-running builds: check `CARGO_BUILD_JOBS` env var for parallel limits
 - Use `./scripts/quality-gates.sh` as final validation before completing tasks

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,1 +1,3 @@
-@AGENTS.md
+# Qwen Code Instructions
+
+Refer to **[AGENTS.md](AGENTS.md)** for the canonical instruction set for this repository.

--- a/README.md
+++ b/README.md
@@ -1,186 +1,94 @@
-# rust-2026-template
+# Rust 2026 Template
 
 [![CI](https://github.com/d-oit/rust-2026-template/actions/workflows/ci.yml/badge.svg)](https://github.com/d-oit/rust-2026-template/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust 1.87+](https://img.shields.io/badge/rust-1.87%2B-orange.svg)](https://www.rust-lang.org)
 
-Best practice 2026 Rust GitHub repository template with AI agent support, CI/CD, quality gates, and modern Rust tooling.
+A production-ready GitHub repository template for modern Rust development in 2026. This template provides a robust workspace foundation with pre-configured CI/CD, quality gates, security auditing, and native support for AI-assisted development.
 
-## Features
+## Who is this for?
 
-- **Workspace structure** — Multi-crate Cargo workspace with `crates/` layout; includes `example-crate` (library) and `sample-app` (binary)
-- **Rust 2024 edition** — MSRV 1.87, pinned via `rust-toolchain.toml`
-- **CI/CD pipeline** — GitHub Actions: format, clippy, nextest, security audit, cargo-deny, MSRV check, release
-- **AI agent support** — `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `QWEN.md`, `opencode.json`
-- **Agent skills** — `.agents/skills/` with 9 reusable skill files
-- **Quality gates** — `scripts/quality-gates.sh` (9 checks) and `scripts/code-quality.sh`
-- **Supply chain security** — `deny.toml` with cargo-deny v2; `cargo-audit` in CI
-- **Modern linting** — `.clippy.toml` with pedantic lints; zero-warnings policy
-- **Formatting** — `rustfmt.toml` with Rust 2024 edition settings
-- **WSL2/Linux optimizations** — mold linker, disk-space-optimized dev profile in `.cargo/config.toml`
-- **cargo-nextest** — `.config/nextest.toml` with `default` and `ci` profiles
-- **Architecture docs** — `plans/adr/`, `docs/architecture/context.yaml`, `agents-docs/`
+- **Developers** starting new production-grade Rust projects.
+- **Teams** wanting to enforce consistent quality standards across multiple crates.
+- **Maintainers** looking for a template with batteries-included CI/CD and security tooling.
+- **AI-Native Engineers** who want their repository to be immediately understandable by coding agents.
 
-## Quick Start
+## Key Features
 
-See **[QUICKSTART.md](QUICKSTART.md)** for the full setup guide.
+- **Modern Workspace Layout** — Multi-crate Cargo workspace using the `crates/` convention.
+- **Rust 2024 Edition** — Pre-configured for the latest language features with a pinned MSRV (1.87+).
+- **Strict Quality Gates** — Local and CI-enforced checks for formatting, linting, and testing.
+- **Supply Chain Security** — Integrated dependency auditing and license policy enforcement.
+- **Performance Optimized** — Configured for fast builds (mold linker) and efficient development.
+- **AI Agent Native** — First-class support for AI coding assistants with structured guidance and skill runbooks.
 
-1. Click **"Use this template"** on GitHub
-2. Check crates.io availability: `cargo search your-crate-name`
-3. Rename `crates/example-crate` to your crate name
-4. Update `Cargo.toml` workspace metadata
-5. Update agent instruction files with your project details
-6. Push to `main` — CI runs automatically
+## Included Tooling
 
-## Workspace Crates
+This template integrates best-in-class tools from the Rust ecosystem:
 
-| Crate | Type | Description |
-|---|---|---|
-| [`example-crate`](crates/example-crate/) | Library | Minimal library placeholder — rename and replace |
-| [`sample-app`](crates/sample-app/) | Binary | Full-featured app demonstrating tokio, clap, serde, tracing, thiserror |
-
-## Agent Skills
-
-All skills live in `.agents/skills/` and are compatible with Claude Code, OpenCode, Gemini CLI, and Qwen Code.
-
-| Skill | Purpose |
-|---|---|
-| [`build-rust`](.agents/skills/build-rust/) | Build Rust projects correctly |
-| [`lint-rust`](.agents/skills/lint-rust/) | Run clippy and formatting checks |
-| [`test-rust`](.agents/skills/test-rust/) | Run tests with cargo-nextest |
-| [`release-rust`](.agents/skills/release-rust/) | Safe release workflow for crates.io |
-| [`crates-io-name-check`](.agents/skills/crates-io-name-check/) | Verify crate name availability before publishing |
-| [`anti-ai-slop`](.agents/skills/anti-ai-slop/) | Audit and fix generic AI-generated Rust code patterns |
-| [`privacy-first`](.agents/skills/privacy-first/) | Prevent email/personal data from entering the codebase |
-| [`skill-creator`](.agents/skills/skill-creator/) | Create and optimize new agent skills |
-| [`skill-evaluator`](.agents/skills/skill-evaluator/) | Evaluate skill quality with structure checks |
-
-## AI Agent Integration
-
-| File | Agent |
-|---|---|
-| `AGENTS.md` | OpenAI Codex and compatible agents |
-| `CLAUDE.md` | Claude Code (Anthropic) |
-| `GEMINI.md` | Gemini CLI (Google) |
-| `QWEN.md` | Qwen Code |
-| `opencode.json` | OpenCode configuration |
-| `.agents/skills/` | Reusable skill runbooks |
+- **Testing**: `cargo-nextest` for faster, cleaner test execution and `proptest` for property-based testing.
+- **Linting**: High-severity `clippy` rules enabled by default in `.clippy.toml`.
+- **Security**: `cargo-audit` for vulnerability scanning and `cargo-deny` for dependency policy management.
+- **CI/CD**: Comprehensive GitHub Actions workflows for continuous integration and automated releases via `cargo-dist`.
+- **Scripts**: Helper scripts in `scripts/` for local development and release management.
 
 ## Repository Structure
 
-```
-rust-2026-template/
-├── .agents/
-│   ├── SKILLS.md            # Skills index
-│   └── skills/              # 9 AI agent skill files
-├── .cargo/
-│   └── config.toml          # Linker, dev profile, cargo aliases
-├── .config/
-│   └── nextest.toml         # nextest profiles (default, ci)
-├── .github/
-│   ├── ISSUE_TEMPLATE/      # Bug report + feature request templates
-│   ├── PULL_REQUEST_TEMPLATE.md
-│   ├── dependabot.yml
-│   └── workflows/
-│       ├── ci.yml           # Format, clippy, test, audit, deny, MSRV
-│       └── release.yml      # Tag-triggered release with cargo-dist
-├── .vscode/
-│   └── settings.json        # rust-analyzer + WSL2 settings
-├── agents-docs/             # Agent reference docs
-│   ├── commands.md
-│   ├── conventions.md
-│   ├── structure.md
-│   └── workflow.md
-├── crates/
-│   ├── example-crate/       # Library placeholder
-│   └── sample-app/          # Binary: tokio, clap, serde, tracing
-├── docs/
-│   └── architecture/
-│       └── context.yaml
-├── plans/
-│   ├── GOAP_STATE.md        # AI agent world state
-│   └── adr/                 # Architecture Decision Records
-├── scripts/
-│   ├── code-quality.sh      # fmt | clippy | audit | check | fix
-│   ├── quality-gates.sh     # 9-step local quality gate runner
-│   └── release-manager.sh   # validate | prepare | publish
-├── src/
-│   └── lib.rs               # Workspace-level lib template stub
-├── .clippy.toml             # Clippy lint configuration
-├── .gitignore
-├── AGENTS.md                # AI agent instructions
-├── CHANGELOG.md
-├── CLAUDE.md
-├── CONTRIBUTING.md
-├── Cargo.toml               # Workspace manifest
-├── GEMINI.md
-├── LICENSE                  # MIT
-├── MIGRATION.md
-├── QUICKSTART.md
-├── QWEN.md
-├── SECURITY.md
-├── deny.toml                # cargo-deny v2 supply chain config
-├── opencode.json
-├── rust-toolchain.toml      # Pinned stable 1.87
-└── rustfmt.toml             # Rustfmt 2024 edition settings
+```text
+.
+├── .agents/             # AI agent skill definitions and runbooks
+├── .cargo/              # Cargo configuration (linker, profiles, aliases)
+├── .github/             # CI/CD workflows and GitHub templates
+├── crates/              # Workspace crates (libraries and applications)
+│   ├── example-crate/   # Template library crate
+│   └── sample-app/      # Template binary application
+├── docs/                # Project documentation
+├── plans/               # Architecture Decision Records (ADR) and roadmap
+├── scripts/             # Development and quality gate scripts
+├── AGENTS.md            # Canonical instructions for AI coding agents
+└── Cargo.toml           # Workspace manifest
 ```
 
-## CI Pipeline
+## Quick Start
 
-Runs on every push to `main`/`develop` and all PRs:
+1. **Use this template**: Click the "Use this template" button on GitHub to create your new repository.
+2. **Setup**: Follow the detailed guide in **[QUICKSTART.md](QUICKSTART.md)** to rename crates and configure metadata.
+3. **Verify**: Run the quality gates to ensure everything is set up correctly:
+   ```bash
+   bash scripts/quality-gates.sh
+   ```
 
-| Job | Tool | Purpose |
-|---|---|---|
-| Format | `cargo fmt` | Formatting check |
-| Clippy | `cargo clippy` | All targets, all features, `-D warnings` |
-| Test | `cargo nextest` | Tests + doc tests, CI profile |
-| Security Audit | `cargo audit` | Known vulnerability check |
-| Dependency Policy | `cargo deny` | License and supply chain checks |
-| MSRV Check | `cargo check` | Verify MSRV 1.87 compatibility |
-| CI Success | Gate | All jobs must pass before merge |
+## CI/CD and Quality Gates
 
-## Testing Conventions
+The project enforces a "zero-warning" policy. The CI pipeline runs on every push and pull request, covering:
 
-Pure functions should be covered with property-based tests using `proptest`.
-See `crates/example-crate/src/lib.rs` for a working example.
-Regression files are saved to `.proptest-regressions/` (gitignored).
+- **Format & Lint**: `cargo fmt` and `cargo clippy`.
+- **Test**: Workspace-wide testing with `cargo nextest`.
+- **Security**: Dependency vulnerability audit and license compliance.
+- **MSRV**: Verification against the Minimum Supported Rust Version.
 
-## Local Quality Gates
+## AI Agent Integration
 
-```bash
-# Run all 9 checks (mirrors CI)
-bash scripts/quality-gates.sh
+This repository is designed to be "Agent-Native." It includes `AGENTS.md` as a canonical source of truth for AI coding assistants (like Claude Code, Gemini CLI, or GitHub Copilot). These instructions help agents understand project conventions, use available tools correctly, and maintain high code quality.
 
-# Auto-fix formatting and clippy issues
-bash scripts/quality-gates.sh --fix
+## Customization Guidance
 
-# Individual operations
-./scripts/code-quality.sh fmt      # format
-./scripts/code-quality.sh clippy   # lint
-./scripts/code-quality.sh audit    # security audit
-./scripts/code-quality.sh check    # full CI parity
-```
+- **Renaming**: Use the instructions in `QUICKSTART.md` to rename the placeholder crates in `crates/`.
+- **Lints**: Adjust `.clippy.toml` if you need to customize linting rules.
+- **Security**: Update `deny.toml` to match your organization's license and dependency policies.
 
-## Cargo Aliases
+## Maintenance
 
-Defined in `.cargo/config.toml`:
-
-```bash
-cargo check-all     # cargo check --workspace --all-features
-cargo test-all      # cargo nextest run --workspace
-cargo fmt-check     # cargo fmt --all -- --check
-cargo lint          # cargo clippy --workspace --all-targets --all-features -- -D warnings
-cargo audit-check   # cargo deny check
-```
+- **Update Toolchain**: Update `rust-toolchain.toml` to bump the required Rust version.
+- **Dependency Updates**: Dependabot is configured to keep your dependencies up to date.
 
 ## Documentation
 
-- **[QUICKSTART.md](QUICKSTART.md)** — Setup guide
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** — Contribution process
-- **[SECURITY.md](SECURITY.md)** — Security policy and vulnerability reporting
-- **[MIGRATION.md](MIGRATION.md)** — Adopt template in existing projects / upgrade between versions
-- **[CHANGELOG.md](CHANGELOG.md)** — Version history
+- [QUICKSTART.md](QUICKSTART.md) — Initial setup and configuration.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — Guidelines for contributing to the project.
+- [SECURITY.md](SECURITY.md) — Security policy and vulnerability reporting.
+- [AGENTS.md](AGENTS.md) — Canonical instructions for AI agents.
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This template integrates best-in-class tools from the Rust ecosystem:
 1. **Use this template**: Click the "Use this template" button on GitHub to create your new repository.
 2. **Setup**: Follow the detailed guide in **[QUICKSTART.md](QUICKSTART.md)** to rename crates and configure metadata.
 3. **Verify**: Run the quality gates to ensure everything is set up correctly:
+
    ```bash
    bash scripts/quality-gates.sh
    ```

--- a/agents-docs/conventions.md
+++ b/agents-docs/conventions.md
@@ -70,3 +70,8 @@ debug = false
 `feat(module): description`
 `fix(module): description`
 `chore(deps): update dependencies`
+
+## CI & Linting
+
+- **Commit Messages**: Body lines must be ≤ 100 characters.
+- **Markdown**: Fenced code blocks must have blank lines before and after.

--- a/plans/GOAP_STATE.md
+++ b/plans/GOAP_STATE.md
@@ -6,7 +6,7 @@
 
 ### Code Quality
 
-- `is_linted`: true (CI — clippy passes with zero warnings, `-D warnings`)
+- `is_linted`: true (CI — clippy passes with zero warnings, -D warnings)
 - `is_formatted`: true (CI — `cargo fmt --all -- --check` passes)
 - `has_zero_warnings`: true (CI — clippy all targets, all features)
 - `is_semver_compliant`: false (not checked yet — run `cargo semver-checks`)
@@ -27,9 +27,10 @@
 ### Documentation
 
 - `has_context_yaml`: true (`docs/architecture/context.yaml`)
-- `has_agents_md`: true
+- `has_agents_md`: true (canonical instruction file)
 - `is_architecture_documented`: true (ADR 0001)
-- `readme_current`: true (updated to reflect two crates and all scripts)
+- `readme_current`: true (human-facing entry point, reflects crates and scripts)
+- `docs_separated`: true (clear split between human and agent documentation)
 
 ### Git
 
@@ -38,7 +39,7 @@
 
 ## Current Phase
 
-`Phase 0: Initialization` — CI pipeline verified and working, documentation updated
+`Phase 0: Initialization` — Documentation overhauled for human/agent clarity
 
 ## Active Blockers
 
@@ -46,9 +47,7 @@
 
 ## Recent Changes
 
-- Added `sample-app` binary crate (tokio, clap, serde, tracing, thiserror)
-- Added `scripts/release-manager.sh`
-- Fixed CI: installed mold linker for clippy, test, and MSRV jobs
-- Fixed CI: disabled sccache for cargo-deny job (runs in Docker)
-- Updated toolchain from 1.85 to 1.87
-- Updated all documentation to reflect current codebase
+- Overhauled documentation structure: README.md for humans, AGENTS.md for agents
+- Simplified agent reference files (CLAUDE.md, GEMINI.md, etc.)
+- Added CI/linting rules to AGENTS.md and conventions.md to prevent regressions
+- Fixed CI failures: MD031 markdown violation and commit message body length


### PR DESCRIPTION
This PR overhauls the project documentation to improve clarity for both humans and AI agents. 

Key changes:
- **README.md**: Completely rewritten to serve as a professional, human-focused introduction to the template. Technical agent tables and jargon have been removed or moved.
- **AGENTS.md**: Established as the primary source of truth for all AI coding assistants. It now contains an accurate inventory of skills from `.agents/skills/`, clear command references, and a standardized change workflow.
- **Agent Reference Files**: `CLAUDE.md`, `GEMINI.md`, `QWEN.md`, and various `rules.md` files in `.cursor/`, `.claude/`, `.gemini/`, `.qwen/`, and `.windsurf/` have been reduced to lightweight wrappers that point to `AGENTS.md`.

This separation ensures that human readers get a clean overview of the project, while AI agents have a single, precise, and well-maintained instruction set to follow, reducing documentation redundancy and potential "prompt drift".

Fixes #52

---
*PR created automatically by Jules for task [10457089684621305913](https://jules.google.com/task/10457089684621305913) started by @d-oit*