### PR TITLE
Sentinel: [improvement] Strictly enforce app_name byte length limit

### DIFF
--- a/crates/sample-app/src/main.rs
+++ b/crates/sample-app/src/main.rs
@@ -148,7 +148,9 @@ fn load_config(config_path: Option<PathBuf>) -> Result<Config> {
         // We check length during sanitization to avoid unnecessary allocations.
         let mut sanitized_name = String::with_capacity(config.app_name.len().min(MAX_APP_NAME_LEN));
         for c in config.app_name.chars().filter(|c| !c.is_control()) {
-            if sanitized_name.len() >= MAX_APP_NAME_LEN {
+            // Security: Check if adding the next character would exceed the byte limit.
+            // Strings are UTF-8, so characters can be up to 4 bytes.
+            if sanitized_name.len() + c.len_utf8() > MAX_APP_NAME_LEN {
                 return Err(AppError::Config(format!(
                     "app_name too long: exceeds maximum of {MAX_APP_NAME_LEN} bytes"
                 )));
@@ -355,6 +357,33 @@ mod tests {
             "log_level": "info",
             "max_items": 100
         }"#;
+        std::fs::write(&file_path, json).unwrap();
+
+        let result = load_config(Some(file_path.clone()));
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("app_name too long")
+        );
+
+        let _ = std::fs::remove_file(file_path);
+    }
+
+    #[test]
+    fn test_load_config_app_name_multibyte_too_long() {
+        let temp_dir = std::env::temp_dir();
+        let file_path = temp_dir.join("multibyte_too_long_config.json");
+        // 63 'a's + '🦀' (4 bytes) = 67 bytes
+        let app_name = format!("{}🦀", "a".repeat(63));
+        let json = format!(
+            r#"{{
+            "app_name": "{app_name}",
+            "log_level": "info",
+            "max_items": 100
+        }}"#
+        );
         std::fs::write(&file_path, json).unwrap();
 
         let result = load_config(Some(file_path.clone()));


### PR DESCRIPTION
Sentinel: [improvement] Strictly enforce app_name byte length limit

### Severity
Low (CWE-20: Improper Input Validation)

### Impact
The `app_name` field in the configuration could exceed its intended 64-byte limit when containing multi-byte UTF-8 characters. While sanitized for control characters, an oversized `app_name` could still lead to minor resource exhaustion or log-filling issues in downstream systems that expect a strict 64-byte maximum.

### Changes
- Updated `load_config` in `crates/sample-app/src/main.rs` to use `c.len_utf8()` to predict the string length before appending a character during sanitization.
- Added a regression test `test_load_config_app_name_multibyte_too_long` that verifies the fix using a 4-byte UTF-8 character ('🦀').

### Verification Steps
- Created a reproduction script that demonstrated the limit bypass (67 bytes accepted instead of 64).
- Verified that the fix correctly rejects the same input with a "Configuration error".
- Ran `cargo test -p sample-app` to ensure all tests pass.
- Verified that all quality gates pass via `./scripts/quality-gates.sh`.

---
*PR created automatically by Jules for task [16286941306308710640](https://jules.google.com/task/16286941306308710640) started by @d-oit*