### PR TITLE
chore: add phased lint guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,11 @@ Specialized workflows are defined as "skills". Always consult the relevant skill
 - **Safety:** `unsafe_code = "forbid"` is enforced at the manifest level. No `unwrap()` in library code.
 - **Documentation:** All public items must have `///` doc comments.
 - **Testing:** Use `proptest` for pure functions and `tokio::test` for async logic.
+- **Lint Phases:** The lint setup uses a phased approach:
+  - **Phase A (Active):** High-signal lints enabled immediately: `float_cmp`, `significant_drop_tightening`, `cast_precision_loss`, `cast_possible_truncation`, `redundant_clone`, `map_unwrap_or`, `unnecessary_map_or`, `missing_const_for_fn`. Fix all warnings from these lints before merging.
+  - **Phase B:** Enable when codebase is stable enough to fix all violations systematically.
+  - **Phase C (Pre-release):** Enable `missing_errors_doc` and `must_use_candidate` before v1.0 public release or crates.io publish. Flip from `allow` to `warn` in `[lints.clippy]`.
+  - When adding new lints, always document the phase and rationale inline in `Cargo.toml`.
 
 ## Core Invariants
 


### PR DESCRIPTION
## Summary

Adds lint phase guidelines to AGENTS.md as required by #86 acceptance criteria.

## Changes

- Added lint phase definitions (A, B, C) to the Code Conventions section of AGENTS.md
- Documents Phase A promoted pedantic/nursery lints: `float_cmp`, `significant_drop_tightening`, `cast_precision_loss`, `cast_possible_truncation`, `redundant_clone`, `map_unwrap_or`, `unnecessary_map_or`, `missing_const_for_fn`
- Adds guidance for Phase C flips before v1.0 release
- Documents the rule: always document phase and rationale inline in `Cargo.toml`

## Acceptance Criteria (from #86)

- [x] AGENTS.md updated with lint phase guidelines for AI agents working on the template
- [x] `cargo clippy --workspace -- -D warnings` passes

Closes #86