### PR TITLE
docs: document release profile trade-offs and include manifest (#84, #85)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,27 @@ This is a **generic Rust template**, not a standalone application. Changes shoul
 - Keep the `example-crate` as a minimal, illustrative placeholder
 - Be documented in `CHANGELOG.md`
 
+### Publishing to crates.io
+
+Every publishable crate **must** define an `include` whitelist in its `Cargo.toml`
+to prevent internal files (plans, agent docs, scripts, CI config) from ending up in
+the published package. The template already sets this up via `[workspace.package]`:
+
+```toml
+include = ["/src", "README.md", "LICENSE"]
+```
+
+When you create a new crate, verify the publish surface is correct:
+
+```bash
+cargo package --list -p your-crate
+```
+
+The output should **not** contain `plans/`, `agents-docs/`, `scripts/`, `.github/`,
+`.agents/`, or `.opencode/`. See
+[Cargo manifest include field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-include-and-exclude-fields)
+for details.
+
 ## Reporting Issues
 
 Open an issue at: <https://github.com/d-oit/rust-2026-template/issues>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,16 @@ rmcp = { version = "=0.3.2", features = ["server", "macros"] }
 [profile.dev]
 opt-level = 0
 
+# Optimised release: maximum runtime performance at the cost of build time.
+# - lto = "fat"       — Full cross-crate link-time optimisation; slower builds,
+#                        smaller and faster binaries. Use "thin" for faster CI
+#                        iterations during development.
+# - codegen-units = 1 — Maximises inlining across modules; hurts parallelism.
+# - panic = "unwind"  — Keeps stack unwinding (required for catch_unwind in
+#                        libraries). Switch to "abort" for binaries when you
+#                        don't need panic handling — cuts binary size ~10 %.
+# - strip = "symbols" — Remove all symbol info; use "debuginfo" if you need
+#                        production backtraces.
 [profile.release]
 opt-level = 3
 lto = "fat"
@@ -157,6 +167,8 @@ codegen-units = 1
 panic = "unwind"
 strip = "symbols"
 
+# Alias for release with the same settings — kept for backward compatibility
+# with tooling that references "release-full".
 [profile.release-full]
 opt-level = 3
 lto = true

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -117,6 +117,10 @@ When using this template, always rename `example-crate` before first publish:
 - Rust toolchain pinned to `1.87` (was `1.85`)
 - `cargo-deny` v2 syntax in `deny.toml`
 - New required skills: `crates-io-name-check` in release workflow
+- **Release profile updated:** `lto` changed from `"thin"` to `"fat"` for maximum
+  runtime performance. `panic = "unwind"` and `strip = "symbols"` are now explicit.
+  If you had overridden the release profile, review your settings against the new
+  defaults. Use `lto = "thin"` during development for faster builds.
 
 ### v0.1.0
 


### PR DESCRIPTION
## Summary

Resolves #84 and #85 by completing the remaining documentation gaps.

### Issue #85 — Release profile documentation
- Added inline comments to `[profile.release]` in `Cargo.toml` explaining trade-offs for `lto`, `panic`, and `strip`
- Added migration note in `MIGRATION.md` about the profile change from `thin` to `fat` LTO

### Issue #84 — Include manifest for crates.io publishing
- Added a **Publishing to crates.io** section in `CONTRIBUTING.md` explaining the `include` whitelist, its purpose, and how to verify with `cargo package --list`

## Verification

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --tests -- -D warnings` passes
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — 24/24 tests pass
- [x] `cargo package --list` — no internal files leaked (plans, agents-docs, scripts, .github, .agents)
