### PR TITLE
feat(dora): measure change lead time in ci pipeline

### DIFF
--- a/.agents/skills/dora-lead-time/SKILL.md
+++ b/.agents/skills/dora-lead-time/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: dora-lead-time
+description: Use this skill to understand and measure Change Lead Time, a key DORA metric that tracks the time from PR creation to merge. This helps in assessing the impact of AI-assisted development on delivery speed.
+license: MIT
+metadata:
+  author: d-oit
+  version: "1.0"
+---
+
+# DORA Lead Time Skill
+
+This skill provides guidance on how to interpret and utilize Change Lead Time data within this repository.
+
+## What is Change Lead Time?
+
+Change Lead Time is the duration from when a Pull Request is opened until it is merged into the `main` branch. It is a critical metric for measuring delivery throughput.
+
+## Why We Measure It
+
+- **Baseline Performance:** Establishing a historical baseline for how long changes take to deliver.
+- **AI ROI:** Proving that agentic workflows and AI tools are actually reducing the time it takes to ship features and fixes.
+- **Process Optimization:** Identifying bottlenecks in the PR review and CI/CD process.
+
+## How to Access Lead Time Data
+
+1. **GitHub Actions Summary:** Every merged PR to `main` will have a "DORA Change Lead Time" section in its action summary.
+2. **Metrics Artifacts:** PR runs generate `dora-metrics.jsonl` artifacts.
+3. **Historical Data:** Periodically, these metrics may be aggregated into a central `analysis/dora-metrics.jsonl` (manual or automated process).
+
+## Agent Responsibilities
+
+- **Self-Improvement:** When completing a task, agents should aim to be efficient without sacrificing quality, as their contribution to Lead Time is now visible.
+- **Reporting:** When asked about project health or velocity, agents should refer to available DORA metrics.
+- **Labeling:** Ensure PRs are labeled with `agentic` if they were primarily authored or assisted by an agent, as the workflow uses this label to categorize metrics.
+
+## Example Metric Entry
+
+```json
+{"date":"2026-05-29","pr":95,"lead_time_hours":3.5,"author":"jules","agent_assisted":true}
+```

--- a/.github/workflows/dora-lead-time.yml
+++ b/.github/workflows/dora-lead-time.yml
@@ -1,0 +1,53 @@
+---
+name: DORA Lead Time
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  lead-time:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Calculate Change Lead Time
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const created = new Date(pr.created_at);
+            const merged = new Date(pr.merged_at);
+            const diffHours = ((merged - created) / 1000 / 60 / 60).toFixed(2);
+
+            core.summary
+              .addHeading('DORA Change Lead Time')
+              .addTable([
+                [{data: 'Metric', header: true}, {data: 'Value', header: true}],
+                ['PR #', String(pr.number)],
+                ['PR Created', pr.created_at],
+                ['Merged At', pr.merged_at],
+                ['Lead Time (hours)', diffHours],
+              ])
+              .write();
+
+            console.log(`Lead Time: ${diffHours} hours`);
+
+            const metric = {
+              date: new Date().toISOString().split('T')[0],
+              pr: pr.number,
+              lead_time_hours: parseFloat(diffHours),
+              author: pr.user.login,
+              agent_assisted: pr.labels.some(l => l.name === 'agentic')
+            };
+
+            const fs = require('fs');
+            fs.writeFileSync('dora-metrics.jsonl', JSON.stringify(metric) + '\n');
+
+      - name: Upload DORA Metrics
+        uses: actions/upload-artifact@v4
+        with:
+          name: dora-metrics-${{ github.event.pull_request.number }}
+          path: dora-metrics.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Specialized workflows are defined as "skills". Always consult the relevant skill
 | `skill-creator` | Guidelines for creating new agent skills |
 | `skill-evaluator` | Quality assessment of existing skills |
 | `codacy` | Codacy static analysis and PR triage workflows |
+| `dora-lead-time` | Measurement and interpretation of Change Lead Time |
 
 ## Change Workflow
 
@@ -92,6 +93,7 @@ Specialized workflows are defined as "skills". Always consult the relevant skill
 - **Privacy:** Adhere to the `privacy-first` skill to avoid leaking PII.
 - **Context Files:** Regenerate `llms.txt` and `llms-full.txt` after significant architectural changes via `bash scripts/generate-llms-txt.sh`.
 - **Lint Phases:** The lint setup uses a phased approach. Promoted pedantic/nursery lints are Phase A (enabled now). Phase C lints (`missing_errors_doc`, `must_use_candidate`) should be flipped to `warn` before v1.0 release.
+- **DORA Metrics:** Change Lead Time (PR open → merge) is tracked in CI. Agents should aim for efficiency and label PRs with `agentic` to enable ROI tracking.
 
 ## Cross-References
 


### PR DESCRIPTION
This PR introduces automated measurement of DORA Change Lead Time (PR open to merge duration) in the CI pipeline. It adds a new GitHub Action that runs on merged PRs to main, calculates the lead time in hours, publishes a summary to the action run, and uploads a `dora-metrics.jsonl` artifact for persistent tracking.

Additionally, it establishes a new agent skill `dora-lead-time` and updates the canonical `AGENTS.md` to instruct AI agents on how to interpret these metrics and contribute to ROI tracking (e.g., by using the `agentic` label).

Fixes #98

---
*PR created automatically by Jules for task [5041372745400778711](https://jules.google.com/task/5041372745400778711) started by @d-oit*