### PR TITLE
Enforce Workspace-wide Forbidden Unsafe Code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ include = [
     "VERSION",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
@@ -83,12 +86,12 @@ mcp = ["dep:rmcp", "cli"]
 tracing-json = ["tracing-subscriber/json"]
 tracing-opentelemetry = ["dep:tracing-opentelemetry", "dep:opentelemetry"]
 
-[lints.rust]
+[workspace.lints.rust]
 missing_docs = "allow"
 unsafe_code = "forbid"
 dead_code = "allow"
 
-[lints.clippy]
+[workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "allow", priority = -1 }
 nursery = { level = "allow", priority = -1 }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 rust-2026-template = { path = ".." }
 

--- a/crates/example-crate/Cargo.toml
+++ b/crates/example-crate/Cargo.toml
@@ -12,5 +12,8 @@ readme = "README.md"
 description = "Example crate in the rust-2026-template workspace"
 include = ["/src", "README.md", "LICENSE"]
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/sample-app/Cargo.toml
+++ b/crates/sample-app/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 description = "Sample application demonstrating the rust-2026-template"
 include = ["/src", "README.md", "LICENSE"]
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "sample-app"
 path = "src/main.rs"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 example-crate = { path = "../../crates/example-crate", version = "0.0.0" }
 anyhow = "1.0"


### PR DESCRIPTION
This change promotes the security-focused linting profile (which includes `unsafe_code = "forbid"`) to the workspace level in the root `Cargo.toml`. It then configures all workspace members (`crates/sample-app`, `crates/example-crate`, `benchmarks`, and `examples/hello_world`) to inherit these lints. This ensures a consistent security posture across the entire project and prevents any crate from accidentally using unsafe code without explicit workspace-level consideration.

---
*PR created automatically by Jules for task [17321405989245690171](https://jules.google.com/task/17321405989245690171) started by @d-oit*