### PR TITLE
feat(agentic): add agent observability via .agents/metrics.jsonl

### DIFF
--- a/.agents/SKILLS.md
+++ b/.agents/SKILLS.md
@@ -16,6 +16,7 @@ Skills are self-contained and can be followed by Claude Code, Gemini CLI, OpenCo
 | `privacy-first` | [skills/privacy-first/SKILL.md](skills/privacy-first/SKILL.md) | Prevent email/personal data from entering the codebase |
 | `skill-creator` | [skills/skill-creator/SKILL.md](skills/skill-creator/SKILL.md) | Create and optimize new agent skills |
 | `skill-evaluator` | [skills/skill-evaluator/SKILL.md](skills/skill-evaluator/SKILL.md) | Evaluate skill quality with structure checks |
+| `metrics-reporter` | [skills/metrics-reporter/SKILL.md](skills/metrics-reporter/SKILL.md) | Mandatory task completion reporting for DORA |
 | `dora-report` | [skills/dora-report/SKILL.md](skills/dora-report/SKILL.md) | Generate automated DORA and agentic metrics reports |
 
 ## Skill Format

--- a/.agents/metrics.jsonl
+++ b/.agents/metrics.jsonl
@@ -1,0 +1,1 @@
+{"timestamp":"2026-05-30T11:53:57Z","agent":"jules","skill":"metrics-reporter","task_description":"Initialize metrics.jsonl and implement agentic observability","success":true,"human_interventions":0}

--- a/.agents/skills/build-rust/SKILL.md
+++ b/.agents/skills/build-rust/SKILL.md
@@ -64,6 +64,10 @@ cargo nextest run --all-features
 cargo test --doc --all-features
 ```
 
+### 8. Report metrics
+
+Call `metrics-reporter` skill.
+
 ## Success Criteria
 
 - `cargo check` exits 0 with no errors
@@ -95,6 +99,7 @@ See `.cargo/config.toml` for WSL2 disk optimization.
 - `test-rust` - Running the test suite
 - `lint-rust` - Deep lint analysis
 - `release-rust` - Creating releases
+- `metrics-reporter` - Mandatory task completion reporting
 
 ## References
 

--- a/.agents/skills/metrics-reporter/SKILL.md
+++ b/.agents/skills/metrics-reporter/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: metrics-reporter
+description: "Append a DORA agentic harness metrics record to .agents/metrics.jsonl after completing any task."
+license: MIT
+metadata:
+  author: jules
+  version: "1.0"
+---
+
+# Skill: metrics-reporter
+
+## Purpose
+
+Append a DORA agentic harness metrics record to `.agents/metrics.jsonl` after completing any task.
+
+## When to use
+
+Call this skill as the LAST step of any other skill execution.
+
+## Steps
+
+1. **Collect task metadata**: agent name, skill used, PR number (if any), success status.
+2. **Count human interventions**: from git log or review comments (0 if none).
+3. **Estimate token usage**: if the runtime provides it.
+4. **Append record**: to `.agents/metrics.jsonl` using the defined schema.
+5. **Stage and commit**: `.agents/metrics.jsonl` with message: `chore(metrics): record agent task completion [skip ci]`.
+
+## Schema Reference
+
+See `.agents/metrics.jsonl` and `agents-docs/dora-metrics.md` for field definitions.
+
+### Minimal append command (bash)
+
+```bash
+cat >> .agents/metrics.jsonl << EOF
+{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","agent":"jules","skill":"build-rust","task_description":"...","success":true,"human_interventions":0}
+EOF
+```

--- a/.agents/skills/skill-evaluator/SKILL.md
+++ b/.agents/skills/skill-evaluator/SKILL.md
@@ -54,7 +54,15 @@ Flag these issues explicitly:
 - `evals/` exists but `evals/evals.json` is missing or invalid JSON
 - eval cases missing `id`, `prompt`, or `expected_output`
 
-### 2. Eval Review
+### 2. Quantitative Evaluation
+
+Consult `.agents/metrics.jsonl` to assess skill performance over time.
+Analyze trends in:
+- Success rate
+- Human intervention rate
+- Token usage and duration
+
+### 3. Eval Review
 
 Read `evals/evals.json` if present and assess whether each case is realistic.
 
@@ -71,7 +79,7 @@ Weak evals include:
 - purely subjective assertions
 - no evidence path for pass/fail
 
-### 3. Live Run
+### 4. Live Run
 
 Run at least one representative prompt from the eval set or create a focused ad hoc prompt.
 
@@ -82,7 +90,7 @@ For each live run:
 - produce the answer or output
 - grade against assertions with evidence
 
-### 4. Baseline Comparison
+### 5. Baseline Comparison
 
 When useful, rerun the same prompt without the skill or against a snapshot of the older skill.
 
@@ -93,7 +101,7 @@ Compare:
 - format compliance
 - time or token cost if available
 
-### 5. Verdict
+### 6. Verdict
 
 End with one of:
 

--- a/.agents/skills/test-rust/SKILL.md
+++ b/.agents/skills/test-rust/SKILL.md
@@ -29,6 +29,10 @@ cargo test --doc --all-features
 cargo llvm-cov nextest --all-features --workspace --html
 ```
 
+### 4. Report metrics
+
+Call `metrics-reporter` skill.
+
 ## Test Organization
 
 ```
@@ -45,7 +49,7 @@ benches/            # Criterion benchmarks
 
 ## Related Skills
 
-- `build-rust`, `lint-rust`, `release-rust`
+- `build-rust`, `lint-rust`, `release-rust`, `metrics-reporter`
 
 ## References
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,26 @@ jobs:
         uses: davidanson/markdownlint-cli2-action@v19
         with:
           globs: "**/*.md"
+      - name: Validate agent metrics schema
+        run: |
+          if [ -f .agents/metrics.jsonl ]; then
+            while IFS= read -r line; do
+              if [ -n "$line" ]; then
+                echo "$line" | python3 -c "
+          import sys, json
+          try:
+              d = json.load(sys.stdin)
+              required = ['timestamp','agent','skill','success']
+              for f in required:
+                  assert f in d, f'Missing field: {f}'
+          except Exception as e:
+              print(f'Validation failed: {e}')
+              sys.exit(1)
+          " || exit 1
+              fi
+            done < .agents/metrics.jsonl
+            echo "Agent metrics validation OK"
+          fi
       - name: Commitlint
         if: >
           github.event_name == 'pull_request' &&

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,25 @@ If you see an open issue with label `release-failure`:
 - **Context Files:** Regenerate `llms.txt` and `llms-full.txt` after significant architectural changes via `bash scripts/generate-llms-txt.sh`.
 - **Lint Phases:** The lint setup uses a phased approach. Promoted pedantic/nursery lints are Phase A (enabled now). Phase C lints (`missing_errors_doc`, `must_use_candidate`) should be flipped to `warn` before v1.0 release.
 
+## Agentic Metrics Reporting
+
+After completing any task, append a JSON record to `.agents/metrics.jsonl`.
+This is mandatory for all skills and enables DORA agentic harness observability.
+
+### Minimal append command (bash)
+
+```bash
+cat >> .agents/metrics.jsonl << EOF
+{"timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","agent":"jules","skill":"build-rust","task_description":"...","success":true,"human_interventions":0}
+EOF
+```
+
+### When to set `human_interventions > 0`
+
+- A human had to correct, rewrite, or revert agent-produced code
+- The PR required a fixup commit after agent submission
+- A review comment explicitly called out an agent error
+
 ## Cross-References
 
 | Topic | Document |

--- a/agents-docs/dora-metrics.md
+++ b/agents-docs/dora-metrics.md
@@ -42,6 +42,48 @@ patch).
 A "Hotfix Release" is any release marked with `metric: change_failure` and
 `type: hotfix` in the metrics log.
 
+## Agentic Metrics
+
+**Definition:** Measurement of AI agent performance, ROI, and human collaboration.
+**Tracking:** Logged to `.agents/metrics.jsonl` by agents upon task completion.
+**Workflow:** `.agents/skills/metrics-reporter/`
+
+### Schema
+
+Each record is a single-line JSON object (NDJSON):
+
+```json
+{
+  "timestamp": "2026-05-29T20:00:00Z",
+  "agent": "jules",
+  "skill": "build-rust",
+  "task_description": "Fix clippy warning in src/lib.rs",
+  "pr_number": 95,
+  "success": true,
+  "human_interventions": 0,
+  "tokens_used": 4200,
+  "duration_seconds": 45,
+  "code_reached_production": true,
+  "notes": ""
+}
+```
+
+### Field Definitions
+
+| Field | Type | Description |
+|---|---|---|
+| `timestamp` | ISO 8601 | When the task completed |
+| `agent` | string | Agent identifier (claude, gemini, qwen, jules, opencode) |
+| `skill` | string | Skill from `.agents/skills/` that was used |
+| `task_description` | string | Short description of the task |
+| `pr_number` | int \| null | Associated PR number if applicable |
+| `success` | bool | Did the agent complete the task without human override? |
+| `human_interventions` | int | Number of times a human corrected the agent output |
+| `tokens_used` | int \| null | Token count if available from the agent |
+| `duration_seconds` | int \| null | Task execution time |
+| `code_reached_production` | bool \| null | Whether the resulting code was merged to main |
+| `notes` | string | Free-form notes (e.g., reason for failure) |
+
 ## Measurement and AI Impact
 
 Following the **2025 DORA AI Report**, we actively monitor these metrics to


### PR DESCRIPTION
This PR implements the requested agentic observability layer for the DORA agentic harness. It introduces a machine-readable record of agent activities in `.agents/metrics.jsonl`, a new `metrics-reporter` skill to handle the logging, and CI validation to ensure data integrity. Documentation in `AGENTS.md` and `agents-docs/dora-metrics.md` has been updated to reflect these changes and provide guidance on reporting human interventions. Existing skills have been wired to call the metrics reporter as their final step.

Fixes #100

---
*PR created automatically by Jules for task [3961195047072729091](https://jules.google.com/task/3961195047072729091) started by @d-oit*