### PR TITLE
chore: bump template version to 0.2.1

### DIFF
--- a/CHANGELOG-TEMPLATE.md
+++ b/CHANGELOG-TEMPLATE.md
@@ -33,6 +33,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.1] - 2026-05-31
+
+### Added
+
+- `validate-agents` CI job with entrypoint validation script.
+- `agent-doc-flow.md` documentation for assistant entrypoint model.
+- ADR 0002: CI optimization and agent validation.
+
+### Changed
+
+- Rust toolchain bumped from 1.87 to 1.88.
+- CI jobs gated on file changes via `dorny/paths-filter`.
+- CI status handling for skipped jobs via `netlify/ci-status`.
+- `rmcp` dependency bumped from 0.3.2 to 1.7.0.
+- `criterion` dependency bumped from 0.5.1 to 0.8.2.
+- `actions/checkout` bumped from 4.3.1 to 6.0.2.
+- `actions/setup-python` bumped from 5.6.0 to 6.2.0.
+- `gitleaks/gitleaks-action` bumped from v2 to v3.
+- `peter-evans/create-pull-request` bumped from 6.1.0 to 8.1.1.
+- `fuzz.yml` and `mutants.yml` updated for path-gated triggers.
+- `CHANGELOG.md` reset to clean template skeleton.
+
+### Fixed
+
+- Clippy `uninlined-format-args` lint under rustc 1.88.
+- Documentation badges and MSRV references updated across all docs.
+
+---
+
 ## [0.2.0] - 2026-05-29
 
 ### Added
@@ -132,7 +161,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rust 2024 edition formatting (rustfmt.toml)
 - Clippy configuration (.clippy.toml)
 
-[Unreleased]: https://github.com/d-oit/rust-2026-template/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/d-oit/rust-2026-template/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/d-oit/rust-2026-template/releases/tag/v0.2.1
 [0.2.0]: https://github.com/d-oit/rust-2026-template/releases/tag/v0.2.0
 [0.1.2]: https://github.com/d-oit/rust-2026-template/releases/tag/v0.1.2
 [0.1.1]: https://github.com/d-oit/rust-2026-template/releases/tag/v0.1.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org)
 [![Mutation Testing](https://github.com/d-oit/rust-2026-template/actions/workflows/mutants.yml/badge.svg)](https://github.com/d-oit/rust-2026-template/actions/workflows/mutants.yml)
-[![Template Version](https://img.shields.io/badge/version-0.2.0-blue)](CHANGELOG-TEMPLATE.md)
+[![Template Version](https://img.shields.io/badge/version-0.2.1-blue)](CHANGELOG-TEMPLATE.md)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 A high-performance, security-hardened GitHub repository template for modern Rust development. This template integrates the Rust 2024 edition, advanced CI/CD pipelines, and AI-native workflows to accelerate building robust applications.


### PR DESCRIPTION
Updates the template version from 0.2.0 to 0.2.1. Version badge in README.md updated to 0.2.1. CHANGELOG-TEMPLATE.md: added v0.2.1 entry with all merged changes since v0.2.0 (toolchain bump, dependency updates, CI optimization, agent validation).