### PR TITLE
test: verify commitlint fix for dependabot PRs

### DIFF
--- a/agents-docs/commands.md
+++ b/agents-docs/commands.md
@@ -65,3 +65,4 @@ cargo run -p sample-app -- --config config.json
 ./scripts/release-manager.sh validate --execute
 cargo release [patch|minor|major]
 ```
+


### PR DESCRIPTION
This PR tests the commitlint fix for dependabot PRs.

The commit message uses the exact dependabot format that previously failed:
- Long body lines (>100 chars) in URLs
- `---\nupdated-dependencies:` separator

Expected: CI should pass commitlint check (previously failed with body-max-line-length).