### PR TITLE
test: verify commitlint fix for dependabot PRs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,3 +58,4 @@ mod tests {
         assert_eq!(add(5, 0), 5);
     }
 }
+// test


### PR DESCRIPTION
This PR tests the commitlint fix for dependabot PRs.

The commit message uses the exact dependabot format that previously failed:
- Long body lines (>100 chars) in URLs
- `---\nupdated-dependencies:` separator

Expected: CI should pass commitlint check (previously failed with body-max-line-length).