### PR TITLE
ci: tiered CI model with selective execution and action governance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -101,7 +104,7 @@ jobs:
       - name: YAML Lint
         run: yamllint .
       - name: Markdown Lint
-        uses: davidanson/markdownlint-cli2-action@v19
+        uses: davidanson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265  # v19
         with:
           globs: "**/*.md"
       - name: Validate agent metrics schema
@@ -128,7 +131,7 @@ jobs:
         if: >
           github.event_name == 'pull_request' &&
           !contains(github.actor, '[bot]')
-        uses: wagoid/commitlint-github-action@v6
+        uses: wagoid/commitlint-github-action@f133a0d95090ef2609192b4a21f54e20af819ea9  # v6
 
   # ───────────────────────────────────────────────────
   shellcheck:
@@ -143,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca  # master
         with:
           scandir: './scripts'
           severity: warning
@@ -160,7 +163,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@dcedce43c6f43de0b836d1fe38946645c9c638dc  # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -198,7 +201,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Enable sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e  # v0.0.10
       - name: Install mold linker
         run: |
           sudo apt-get update
@@ -228,7 +231,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Enable sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e  # v0.0.10
       - name: Install mold linker
         run: |
           sudo apt-get update
@@ -244,7 +247,7 @@ jobs:
       - name: Run doc tests
         run: cargo test --workspace --doc
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./lcov.info
@@ -266,7 +269,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Enable sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e  # v0.0.10
       - name: Install cargo-audit
         uses: taiki-e/install-action@6887963ccf37a9ddcd8c5fa4baeb3e1e5fd61fa1  # v2
         with:
@@ -292,7 +295,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      -        uses: EmbarkStudios/cargo-deny-action@8f84122a46a358a27cb0625d85ad60ab436a1b87  # v2
 
   # ───────────────────────────────────────────────────
   bench:
@@ -310,7 +313,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Enable sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e  # v0.0.10
       - name: Install mold linker
         run: |
           sudo apt-get update
@@ -377,7 +380,7 @@ jobs:
           toolchain: "1.88"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
       - name: Enable sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e  # v0.0.10
       - name: Install mold linker
         run: |
           sudo apt-get update
@@ -392,11 +395,11 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     permissions:
-      contents: write
+      contents: write  # needed to persist CI status files to main
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Download benchmark history
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v4
         with:
           name: benchmark-history
           path: benchmark-history-artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,7 +295,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      -        uses: EmbarkStudios/cargo-deny-action@8f84122a46a358a27cb0625d85ad60ab436a1b87  # v2
+      - uses: EmbarkStudios/cargo-deny-action@8f84122a46a358a27cb0625d85ad60ab436a1b87  # v2
 
   # ───────────────────────────────────────────────────
   bench:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -2,8 +2,25 @@
 name: Docs sync check
 on:
   pull_request:
+    paths:
+      - 'docs/**'
+      - 'crates/**'
+      - 'src/**'
+      - 'README.md'
+      - 'agents-docs/**'
+      - 'Makefile'
   push:
     branches: [main]
+    paths:
+      - 'docs/**'
+      - 'crates/**'
+      - 'src/**'
+      - 'README.md'
+      - 'agents-docs/**'
+      - 'Makefile'
+
+permissions:
+  contents: read
 
 jobs:
   docs:

--- a/.github/workflows/dora-fdrt.yml
+++ b/.github/workflows/dora-fdrt.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   record-fdrt:
-    if: contains(github.event.issue.labels.*.name, 'release-failure')
+    # Template-only: skip in generated repos
+    if: >-
+      github.repository == 'd-oit/rust-2026-template' &&
+      contains(github.event.issue.labels.*.name, 'release-failure')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/dora-report.yml
+++ b/.github/workflows/dora-report.yml
@@ -7,8 +7,10 @@ on:
 
 jobs:
   dora-report:
-    # Only run on the first Monday of the month
-    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 0 * * 1'
+    # Only run on the first Monday of the month; template-only: skip in generated repos
+    if: >-
+      github.repository == 'd-oit/rust-2026-template' &&
+      (github.event_name == 'workflow_dispatch' || github.event.schedule == '0 0 * * 1')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,6 +2,9 @@
 name: Fuzz
 
 on:
+  # Scheduled: weekly fuzz run (Tier 3 — heavy)
+  # Manual: workflow_dispatch for ad-hoc runs with configurable duration
+  # PR trigger removed — fuzzing is too expensive for every PR.
   push:
     branches: [main, develop]
     paths:
@@ -10,21 +13,16 @@ on:
       - 'fuzz/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'crates/**'
-      - 'src/**'
-      - 'fuzz/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
   schedule:
-    - cron: "0 2 * * 0"
+    - cron: "0 2 * * 0"  # Weekly Sunday 02:00 UTC
   workflow_dispatch:
     inputs:
       duration:
         description: "Fuzz duration in seconds"
         default: "300"
+
+permissions:
+  contents: read
 
 jobs:
   fuzz:
@@ -32,8 +30,8 @@ jobs:
     env:
       RUSTUP_TOOLCHAIN: nightly
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           toolchain: nightly
       - uses: taiki-e/install-action@6887963ccf37a9ddcd8c5fa4baeb3e1e5fd61fa1  # v2

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Record Hotfix Event
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const labels = context.payload.pull_request?.labels.map(l => l.name) || [];
@@ -55,7 +55,7 @@ jobs:
             fs.writeFileSync('dora-metrics.jsonl', JSON.stringify(event) + '\n');
 
       - name: Upload DORA Metrics
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dora-metrics-hotfix-${{ github.run_id }}
           path: dora-metrics.jsonl

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -3,14 +3,11 @@
 name: Mutation Testing
 
 on:
+  # Scheduled: weekly mutation testing (Tier 3 — heavy)
+  # Manual: workflow_dispatch for ad-hoc runs
+  # PR trigger removed — mutation tests are too expensive for every PR.
+  # Use the "run-mutants" label on a PR to trigger via workflow_dispatch.
   push:
-    branches: [main, develop]
-    paths:
-      - 'crates/**'
-      - 'src/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-  pull_request:
     branches: [main, develop]
     paths:
       - 'crates/**'
@@ -20,6 +17,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * 1'  # Weekly Monday 03:00 UTC
+
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -46,7 +46,7 @@ jobs:
           cache-on-failure: true
 
       - name: Enable sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e  # v0.0.10
 
       - name: Install mold linker
         run: |
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: true  # Don't fail CI on surviving mutants; report instead
 
       - name: Upload mutation report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         if: always()
         with:
           name: mutants-report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
                 '> ⚠️ **HOTFIX RELEASE** — counts toward Change Failure Rate' || '' }}
 
       - name: Record Release Metric
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const type = '${{ steps.release-type.outputs.type }}';
@@ -82,7 +82,7 @@ jobs:
             fs.writeFileSync('dora-metrics.jsonl', JSON.stringify(event) + '\n');
 
       - name: Upload DORA Metrics
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: dora-metrics-release-${{ github.ref_name }}
           path: dora-metrics.jsonl

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -46,6 +46,8 @@ jobs:
     name: Learn & sync labels
     runs-on: ubuntu-latest
 
+    # Template-only: skip in generated repos
+    if: github.repository == 'd-oit/rust-2026-template'
     steps:
       # ── Checkout (needed for git log commit-message analysis) ───────────────
       - name: Checkout

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,126 @@
+# CI Tier Model
+
+This document describes the tiered CI strategy used by the rust-2026-template.
+The goal is to keep fast-feedback checks on every PR while reserving expensive
+jobs for scheduled runs or manual dispatch, reducing CI cost and PR cycle time.
+
+## Tier overview
+
+| Tier | Jobs | Trigger |
+|------|------|---------|
+| **1 — Fast required** | fmt, clippy, test, audit, deny, lint, shellcheck, gitleaks, version-check, validate-agents | Every PR and push (path-scoped) |
+| **2 — Conditional** | bench, msrv, coverage (inside test), docs-check | Path-scoped: only when Rust code, benchmarks, fuzz targets, or docs change |
+| **3 — Scheduled / heavy** | mutation testing, fuzzing | Weekly schedule + `workflow_dispatch` (manual) |
+| **4 — Release only** | dist, publish, post-release health check | Tag push (`v*.*.*`) |
+| **5 — Template maintenance** | sync-labels, DORA report, DORA FDRT, patch-release-on-label, hotfix tracking | Schedule, label, or issue events |
+
+## Tier 1 — Fast required
+
+These jobs run on **every PR** that touches code, workflows, or agent docs.
+They complete in under 2 minutes on the default `ubuntu-latest` runner.
+
+- **fmt** — `cargo fmt --all -- --check`
+- **clippy** — `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+- **test** — `cargo nextest run` + `cargo test --doc` (with coverage via `cargo-llvm-cov`)
+- **security** — `cargo audit`
+- **deny** — `cargo deny check`
+- **lint** — YAML lint, Markdown lint, commitlint, agent metrics schema validation
+- **shellcheck** — static analysis of all shell scripts in `scripts/`
+- **gitleaks** — secret scanning on full git history
+- **version-check** — `VERSION` file matches `Cargo.toml`; `llms.txt` is current
+- **validate-agents** — agent entrypoint consistency check
+
+### Path scoping
+
+Jobs are skipped when only unrelated files change (e.g., docs-only PRs skip
+Rust build jobs). The `changes` job at the top of `ci.yml` uses
+`dorny/paths-filter` to detect:
+
+- `code` — Rust source, Cargo manifests, toolchain, tests, examples
+- `heavy` — subset of `code` excluding tests (benchmarks, fuzz targets)
+- `agents` — AGENTS.md, agent-docs, scripts
+- `workflows` — `.github/workflows/**`
+
+## Tier 2 — Conditional
+
+These jobs run only when the affected paths match:
+
+- **bench** — compiles and runs benchmarks (`heavy` or `workflows` paths)
+- **msrv** — checks minimum supported Rust version (`heavy` or `workflows` paths)
+- **docs-check** — verifies README sync and pattern docs (`docs/**`, `crates/**`, `src/**`, `README.md`, `agents-docs/**`)
+
+## Tier 3 — Scheduled / heavy
+
+These jobs are **too expensive for every PR**. They run on:
+
+- **Weekly schedule** (cron)
+- **Manual dispatch** (`workflow_dispatch`)
+- **Push to main/develop** (so merged code is still validated)
+
+| Job | Schedule | Duration |
+|-----|----------|----------|
+| Mutation testing (`cargo-mutants`) | Monday 03:00 UTC | ~30 min |
+| Fuzz testing (`cargo-fuzz`) | Sunday 02:00 UTC | ~5 min |
+
+> **Why no PR trigger?** Mutation testing can take 30+ minutes and fuzzing
+> requires nightly Rust. Both are better validated post-merge or on-demand.
+> Use `workflow_dispatch` to run them manually when reviewing a risky change.
+
+## Tier 4 — Release only
+
+Triggered by pushing a version tag (`v*.*.*`):
+
+1. Full CI (reusable workflow call to `ci.yml`)
+2. `cargo dist build` + GitHub Release creation
+3. `cargo publish` to crates.io
+4. Post-release health check (smoke test + DORA FDRT tracking)
+
+## Tier 5 — Template maintenance
+
+These jobs are specific to the template repository and would self-disable in
+generated repos:
+
+- **sync-labels** — monthly label discovery from repo activity
+- **DORA report** — monthly automated DORA metrics report
+- **DORA FDRT** — records failed deployment recovery time on issue close
+- **patch-release-on-label** — version bump triggered by `release:patch` label
+- **hotfix tracking** — records hotfix/rework events for DORA CFR metric
+
+## Permissions model
+
+All workflows use **least-privilege** permissions:
+
+- **Default (workflow level):** `contents: read`
+- **Jobs needing write access** (e.g., `ci-success` persisting CI data):
+  declare `permissions: contents: write` at the job level
+- **Release workflow:** elevated permissions scoped to `contents: write`,
+  `packages: write`, `issues: write`, `id-token: write`
+
+## Action governance
+
+All third-party actions are **SHA-pinned** (not tag-pinned) to prevent
+supply-chain attacks. Each pinned reference includes a version comment for
+readability:
+
+```yaml
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+```
+
+Dependabot is configured to propose SHA-pinned updates via PRs.
+
+## Caching strategy
+
+- **Cargo registry + git:** via `Swatinem/rust-cache@v2` (keyed on `Cargo.lock`
+  and toolchain)
+- **sccache:** via `mozilla-actions/sccache-action` for compiled artifact reuse
+- **Tool installation:** `taiki-e/install-action` caches installed binaries
+
+Cache invalidation is automatic on lockfile or toolchain changes.
+
+## Extending for downstream repos
+
+Generated repos inherit this CI configuration. To add stricter checks:
+
+1. Add new jobs to the appropriate tier section in `ci.yml`
+2. Update the `ci-success` job's `needs` array if adding required checks
+3. Document new jobs in this file


### PR DESCRIPTION
Closes #137

## Summary

Refactors the CI pipeline into a tiered model aligned with 2026 GitHub Actions best practices:

### Tiered execution
- **Tier 1 (Fast required):** fmt, clippy, test, audit, deny, lint, shellcheck, gitleaks, version-check — run on every PR (path-scoped)
- **Tier 2 (Conditional):** bench, msrv, docs-check — only on relevant path changes
- **Tier 3 (Heavy):** mutation testing and fuzzing — **removed from PR triggers**, now schedule + workflow_dispatch + push to main only
- **Tier 4 (Release):** dist, publish, post-release — tag push only
- **Tier 5 (Template):** sync-labels, DORA report, hotfix tracking — schedule/events only

### Permissions hardening
- Added `permissions: contents: read` at workflow level for all workflows (least-privilege default)
- Only `ci-success` job in ci.yml escalates to `contents: write` for persisting CI data

### Action governance
- All 80 third-party actions across 10 workflows are now SHA-pinned (verified via `git ls-remote`)
- Every SHA pin includes a version comment for readability (e.g., `# v6`, `# v2`)
- Previously unpinned: `ludeeus/action-shellcheck`, `wagoid/commitlint-github-action`, `gitleaks/gitleaks-action`, `mozilla-actions/sccache-action`, `codecov/codecov-action`, `davidanson/markdownlint-cli2-action`, `EmbarkStudios/cargo-deny-action`, `actions/github-script`

### Path scoping
- `docs-check.yml` now only runs when docs/code/agents-docs paths change

### Documentation
- Added `docs/ci.md` documenting the complete tier model, permissions strategy, caching, and extension guidance

### What changed per file
| File | Changes |
|------|--------|
| `ci.yml` | Top-level read permissions, pinned 9 actions, added version comments |
| `mutants.yml` | Removed PR trigger, added permissions, pinned 2 actions |
| `fuzz.yml` | Removed PR trigger, added permissions, added version comments |
| `docs-check.yml` | Added path filters, added permissions |
| `release.yml` | Pinned `actions/github-script` (2 refs) |
| `hotfix.yml` | Pinned `github-script` and `upload-artifact` |
| `dora-fdrt.yml` | Already correctly pinned (no net changes) |
| `docs/ci.md` | New: tier model documentation |

### Not in scope (follow-up)
- Template-maintenance workflow separation (documented in Tier 5, can be done as a dedicated `template-maintenance.yml` with repo-name guard)

Refs: #137