### PR TITLE
Enforce workspace-wide security lints and forbid unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ include = [
     "VERSION",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
@@ -83,12 +86,12 @@ mcp = ["dep:rmcp", "cli"]
 tracing-json = ["tracing-subscriber/json"]
 tracing-opentelemetry = ["dep:tracing-opentelemetry", "dep:opentelemetry"]
 
-[lints.rust]
+[workspace.lints.rust]
 missing_docs = "allow"
 unsafe_code = "forbid"
 dead_code = "allow"
 
-[lints.clippy]
+[workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 pedantic = { level = "allow", priority = -1 }
 nursery = { level = "allow", priority = -1 }

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 publish = false
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 rust-2026-template = { path = ".." }
 sample-app = { path = "../crates/sample-app" }

--- a/crates/example-crate/Cargo.toml
+++ b/crates/example-crate/Cargo.toml
@@ -12,5 +12,8 @@ readme = "README.md"
 description = "Example crate in the rust-2026-template workspace"
 include = ["/src", "README.md", "LICENSE"]
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/example-registry-pattern/Cargo.toml
+++ b/crates/example-registry-pattern/Cargo.toml
@@ -5,5 +5,8 @@ edition.workspace = true
 description = "Template pattern: registry-based handler dispatch"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror = { workspace = true }

--- a/crates/example-storage-pattern/Cargo.toml
+++ b/crates/example-storage-pattern/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 description = "Template pattern: trait-only storage layer with swappable backends"
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 default = []
 sqlite = ["dep:rusqlite"]

--- a/crates/sample-app/Cargo.toml
+++ b/crates/sample-app/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 description = "Sample application demonstrating the rust-2026-template"
 include = ["/src", "README.md", "LICENSE"]
 
+[lints]
+workspace = true
+
 [lib]
 name = "sample_app"
 path = "src/main.rs"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 example-crate = { path = "../../crates/example-crate", version = "0.0.0" }
 anyhow = "1.0"


### PR DESCRIPTION
This PR implements workspace-wide enforcement of security lints as directed by the project's security standards. 

By moving the lint configuration to `[workspace.lints]` and having every crate (including the root, examples, and benchmarks) inherit from it via `[lints] workspace = true`, we ensure a consistent and hardened security baseline across the entire repository. Specifically, this enforces `unsafe_code = "forbid"` and several Phase A correctness lints from Clippy.

Verified the enforcement by successfully triggering clippy errors with a deliberate `unsafe` block in a sub-crate, and confirmed that the root package also correctly inherits the lints after fixing a TOML ordering issue. All existing tests pass.

---
*PR created automatically by Jules for task [16727157594282949595](https://jules.google.com/task/16727157594282949595) started by @d-oit*