### PR TITLE
Add SessionStart hook for agent context injection

### DIFF
--- a/.agents/events/2026/06/06/2026-06-06T17-39-51Z-Jules-feat-session-start-hook.json
+++ b/.agents/events/2026/06/06/2026-06-06T17-39-51Z-Jules-feat-session-start-hook.json
@@ -1,0 +1,20 @@
+{
+  "event_id": "1780767591-Jules",
+  "task_id": "feat-session-start-hook",
+  "parent_task_id": null,
+  "workflow_id": null,
+  "agent_id": "Jules",
+  "agent_type": "automated",
+  "skill": "feat-implementation",
+  "skill_version": "1.0.0",
+  "status": "success",
+  "started_at": "2026-06-06T17:29:51Z",
+  "finished_at": "2026-06-06T17:39:51Z",
+  "success": true,
+  "human_interventions": 0,
+  "git_branch": "jules-17567871820139177306-4cb7cbc9",
+  "git_sha": "d6b7ab6",
+  "pr_number": null,
+  "artifacts": ["hooks/session-start.sh", "docflow.json", ".claude/settings.json"],
+  "notes": "Added SessionStart hook, docflow.json, and documented in AGENTS.md"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "SessionStart": "bash hooks/session-start.sh"
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,14 @@ For multi-agent orchestration, skill chaining, and handoff protocol, see **[`.ag
 | `codacy` | Codacy static analysis and PR triage workflows (see `.codacy/` for tool configs) |
 | `dora-report` | Automated DORA and agentic metrics reporting (run monthly) |
 
+## Session Bootstrap
+
+The repository includes a `SessionStart` hook to auto-inject project context at the start of an agent session. This helps agents orient themselves quickly without manual discovery.
+
+- **Hook:** `hooks/session-start.sh`
+- **Config:** `docflow.json`
+- **Integration:** Registered in `.claude/settings.json` for Claude.
+
 ## Responding to Release Failures
 
 If you see an open issue with label `release-failure`:

--- a/docflow.json
+++ b/docflow.json
@@ -1,0 +1,5 @@
+{
+  "docs_root": "docs",
+  "changelog": "CHANGELOG.md",
+  "hook": "hooks/session-start.sh"
+}

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SessionStart hook — injects project doc context into agent sessions (read-only)
+set -euo pipefail
+
+DOCS_ROOT="${DOCS_ROOT:-docs}"
+CHANGELOG="${CHANGELOG:-CHANGELOG.md}"
+
+echo "=== Project Context ==="
+echo "Docs root : $DOCS_ROOT"
+
+# Print crate structure
+if [ -f "Cargo.toml" ]; then
+  echo "--- Cargo.toml (workspace/package) ---"
+  grep -E '^(name|version|\[workspace\]|members)' Cargo.toml | head -20
+fi
+
+# Print doc structure map
+if [ -d "$DOCS_ROOT" ]; then
+  echo "--- Docs Map ---"
+  find "$DOCS_ROOT" -maxdepth 2 -type f -name '*.md' | sort
+fi
+
+# Print latest changelog entry
+if [ -f "$CHANGELOG" ]; then
+  echo "--- Latest Changelog Entry ---"
+  awk '/^## /{count++; if(count==2) exit} count==1{print}' "$CHANGELOG"
+fi
+
+echo "====================="


### PR DESCRIPTION
Added a `SessionStart` hook to solve the agent cold-start problem. The hook automatically provides project structure and documentation context at the beginning of an agent session. Created `hooks/session-start.sh`, `docflow.json`, and `.claude/settings.json`, and updated `AGENTS.md`. Verified with quality gates and script execution.

Fixes #145

---
*PR created automatically by Jules for task [17567871820139177306](https://jules.google.com/task/17567871820139177306) started by @d-oit*