### PR TITLE
feat: bootstrap opencode session-continuity support

### DIFF
--- a/.opencode/commands/generate-docs.md
+++ b/.opencode/commands/generate-docs.md
@@ -1,0 +1,20 @@
+# Command: generate-docs
+
+## Description
+Generates a Rust-scoped symbol inventory to assist agents in understanding the public API surface of the workspace.
+
+## Execution Protocol
+1. **Workspace Discovery**: Identify all workspace members defined in `Cargo.toml` and located in `crates/`.
+2. **Symbol Extraction**: For each crate, extract public symbols including:
+   - `struct` and `enum` definitions
+   - `trait` definitions
+   - Public functions (`pub fn`)
+   - Associated `///` documentation comments
+3. **Documentation Generation**:
+   - Primary output: `docs/symbols/` directory.
+   - Create one file per crate: `docs/symbols/<crate_name>.md`.
+4. **Machine Context**: Trigger `bash scripts/generate-llms-txt.sh` to ensure `llms.txt` and `llms-full.txt` are up-to-date with any new documentation.
+
+## Guidelines
+- This command is intended to complement `cargo doc`, providing a more LLM-friendly, flat representation of the codebase.
+- Focus on the "what" (public interface) rather than the "how" (internal implementation).

--- a/.opencode/commands/resume.md
+++ b/.opencode/commands/resume.md
@@ -1,0 +1,16 @@
+# Command: resume
+
+## Description
+Resumes the agent session from the last recorded state to ensure continuity across interruptions.
+
+## Execution Protocol
+1. **Status Anchor**: Read `plans/_status.json` to identify the `active_plan` and any `handover_ref`.
+2. **Handover Recovery**: If `handover_ref` points to a file, read it to restore the previous session's "thought process" and specific context.
+3. **Plan Alignment**: Load the markdown file associated with the `active_plan` (typically in the `plans/` directory).
+   - Identify the current `phase`.
+   - Identify the next pending `todo` item.
+4. **World State**: Read `plans/GOAP_STATE.md` to align with the executable truth of the repository.
+5. **Validation**: Run `./scripts/code-quality.sh check` to ensure the workspace is in a healthy state for continuation.
+
+## Goal
+Restore the agent's mental model to the exact point of the last save or handoff.

--- a/plans/_status.json
+++ b/plans/_status.json
@@ -1,0 +1,5 @@
+{
+  "active_plan": null,
+  "phases": [],
+  "handover_ref": null
+}


### PR DESCRIPTION
Bootstrapped opencode session-continuity support by adding necessary metadata and command stubs.

Key changes:
- Created `plans/.gitkeep` to ensure the directory is tracked.
- Created `plans/_status.json` as a structured anchor for session state.
- Created `.opencode/commands/resume.md` defining the session resumption protocol.
- Created `.opencode/commands/generate-docs.md` for generating a Rust-scoped symbol inventory.

These additions allow AI agents to maintain continuity across sessions and quickly understand the public API surface of projects derived from this template.

Fixes #146

---
*PR created automatically by Jules for task [5258054128534292420](https://jules.google.com/task/5258054128534292420) started by @d-oit*