### PR TITLE
chore(quality): enforce local gates for fmt, commitlint, and agents

### DIFF
--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -1,0 +1,12 @@
+# <type>(<scope>): <short summary — max 72 chars>
+#
+# Body (optional) — wrap ALL lines at 100 characters or less
+# Explain WHY this change is necessary, not just WHAT it does.
+#
+# Footer (optional) — wrap ALL lines at 100 characters or less
+# Refs: #<issue>  |  Closes: #<issue>  |  BREAKING CHANGE: <description>
+#
+# Conventional Commit types: feat, fix, docs, style, refactor,
+# perf, test, build, ci, chore, revert
+#
+# body-max-line-length: 100 characters (enforced by commitlint)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ The repository includes a `SessionStart` hook to auto-inject project context at 
 ## Coding Conventions
 
 ### Rust & Concurrency
+
 - **Edition:** Rust 2024 (MSRV 1.88).
 - **Safety:** `#![forbid(unsafe_code)]` at workspace and crate roots.
 - **Errors:** `thiserror` for libraries, `anyhow` for binaries. No `unwrap()` in libs.
@@ -56,6 +57,7 @@ The repository includes a `SessionStart` hook to auto-inject project context at 
 - **Tracing:** Minimize CLI tracing metadata (thread IDs/names) unless high-concurrency.
 
 ### Security & Configuration
+
 - **Hardening:** Enforce `#[serde(deny_unknown_fields)]` on config structs.
 - **Safe Loading:** Use `file.take(limit)` and `is_file()` check before reading.
 - **Validation:** Sanitize strings (`is_control()`) and enforce bounds on numeric fields.
@@ -63,11 +65,59 @@ The repository includes a `SessionStart` hook to auto-inject project context at 
 - **Secrets:** Never hardcode; use environment variables or `.env`.
 
 ### Quality & Workflow
+
 - **File Size:** Max 500 LOC per source file.
 - **Docs:** All public items must have `///` doc comments.
 - **TDD:** Add or update tests before implementing logic.
 - **Search:** Always use `--exclude-dir=target` (and `.git`) in search commands.
 - **Context:** Run `bash scripts/generate-llms-txt.sh` after significant arch changes.
+
+## Mandatory Pre-Push Rules (ALL agents and bots)
+
+> These rules are REQUIRED before every `git push`. CI is a verifier,
+> not the first place failures should be caught. Violations cause red PRs
+> and waste CI minutes.
+
+### Formatting
+
+1. After writing or modifying any `.rs` file, run `cargo fmt --all`.
+2. Before staging a commit, verify with `cargo fmt --all -- --check`.
+3. If the check fails, run `cargo fmt --all`, re-stage, and re-commit.
+4. **Never push with a failing `cargo fmt --check`.**
+
+### Quality Gates
+
+5. Before every `git push`, run `bash scripts/quality-gates.sh`.
+6. If any gate fails, fix the issue before pushing. Do not skip or bypass.
+
+### Commit Messages
+
+7. Use Conventional Commits: `<type>(<scope>): <summary>`.
+8. **Wrap every line in the commit body at 100 characters or less** (`body-max-line-length`).
+9. **Wrap every line in the commit footer at 100 characters or less** (`footer-max-line-length`).
+10. If generating a long description, split it into short wrapped lines. Do not write
+    one long sentence as a single body line.
+11. Use `.gitmessage.txt` as a reference for the expected format.
+
+### Example of a valid commit body
+
+```
+feat(mcp): add tool validation in McpServer::execute_tool
+
+Prevent panics on non-finite float results by replacing unwrap() with
+proper error handling. Return a structured error when serde_json
+cannot represent the value (e.g. Infinity or NaN).
+
+Fixes: #160
+```
+
+### Example of an INVALID commit body (violates body-max-line-length)
+
+```
+feat(mcp): add tool validation in McpServer::execute_tool
+
+- Replaced `unwrap()` on `serde_json::Number::from_f64()` with proper error handling in `CalcTool::handle` to prevent panics on Infinity or NaN results.
+```
 
 ## Change Workflow
 
@@ -75,19 +125,23 @@ The repository includes a `SessionStart` hook to auto-inject project context at 
 2. **Plan:** Identify affected files and required test coverage.
 3. **Test-First:** Add or update tests before logic implementation.
 4. **Implement:** Write code adhering to conventions.
-5. **Quality Check:** Run `./scripts/quality-gates.sh`.
-6. **Commit:** Use conventional commit format.
+5. **Format:** Run `cargo fmt --all` and verify with `cargo fmt --all -- --check`.
+6. **Quality Check:** Run `./scripts/quality-gates.sh`.
+7. **Commit:** Use Conventional Commit format. Wrap body lines at 100 chars.
+8. **Push:** Only push after all local checks pass.
 
 ## Agentic Metrics Reporting
 
 After completing any task, write a JSON event file to `.agents/events/YYYY/MM/DD/`.
-This event-based pattern is also used for CI benchmarks in `benchmarks/events/` to prevent merge conflicts.
-See `.agents/skills/metrics-reporter/` for the schema and event writing procedures.
-Set `human_interventions > 0` if a human corrected your code or provided rework instructions.
+This event-based pattern is also used for CI benchmarks in `benchmarks/events/` to prevent
+merge conflicts. See `.agents/skills/metrics-reporter/` for the schema and event writing
+procedures. Set `human_interventions > 0` if a human corrected your code or provided rework
+instructions.
 
 ## Release Failures (Priority 1)
 
 If a `release-failure` issue is open:
+
 1. Create a `hotfix/` branch and apply the minimal fix.
 2. Open a PR with the `hotfix` label.
 3. Close the issue with: `Recovered at: <TIMESTAMP>. FDRT: <HOURS>`.

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,5 +1,10 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Enforce 100-char body/footer line length (matches CI rule)
+    'body-max-line-length': [2, 'always', 100],
+    'footer-max-line-length': [2, 'always', 100],
+  },
   ignores: [
     (message) => message.includes('Co-authored-by: codacy-production[bot]'),
     (message) => /^Update .*/.test(message) && message.includes('bot'),

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# commit-msg: validate commit message with commitlint before it is accepted.
+# Install via: bash scripts/setup-hooks.sh
+set -euo pipefail
+
+MSG_FILE="$1"
+
+if command -v npx &>/dev/null; then
+  npx --yes commitlint --edit "$MSG_FILE"
+else
+  echo "[commit-msg] WARNING: npx not found, skipping commitlint validation."
+  echo "[commit-msg] Install Node.js to enable local commit message validation."
+fi

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# pre-push: run quality gates before every push.
+# Install via: bash scripts/setup-hooks.sh
+set -euo pipefail
+
+echo "[pre-push] Running cargo fmt check..."
+if ! cargo fmt --all -- --check; then
+  echo "[pre-push] FAILED: Unformatted Rust code detected."
+  echo "[pre-push] Run: cargo fmt --all  then re-commit and push."
+  exit 1
+fi
+
+echo "[pre-push] Running full quality gates..."
+if ! bash scripts/quality-gates.sh; then
+  echo "[pre-push] FAILED: quality-gates.sh did not pass."
+  exit 1
+fi
+
+echo "[pre-push] All checks passed."

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# setup-hooks.sh: install Git hooks and commit template for this repo.
+# Run once after cloning: bash scripts/setup-hooks.sh
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="$REPO_ROOT/hooks"
+GIT_HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+echo "Installing Git hooks from $HOOKS_DIR..."
+
+for hook in commit-msg pre-push; do
+  src="$HOOKS_DIR/$hook"
+  dst="$GIT_HOOKS_DIR/$hook"
+  if [ -f "$src" ]; then
+    cp "$src" "$dst"
+    chmod +x "$dst"
+    echo "  Installed: $hook"
+  else
+    echo "  WARNING: $src not found, skipping."
+  fi
+done
+
+echo "Setting commit template..."
+git config commit.template "$REPO_ROOT/.gitmessage.txt"
+
+echo ""
+echo "Done. To also install pre-commit framework hooks, run:"
+echo "  pre-commit install"
+echo "  pre-commit install --hook-type commit-msg"


### PR DESCRIPTION
## Summary

Prevents the class of CI failures seen in PR #161 (unformatted Rust code,
commit body lines exceeding 100 chars) by moving checks left into local
git hooks and explicit agent instructions.

## What changed

### New files

- `hooks/commit-msg` — runs `commitlint` on every commit message locally
- `hooks/pre-push` — runs `cargo fmt --check` + `scripts/quality-gates.sh`
  before every push
- `scripts/setup-hooks.sh` — one-command installer for new contributors
  and CI onboarding
- `.gitmessage.txt` — commit template showing 100-char body wrap rule

### Updated files

- `commitlint.config.cjs` — added explicit `body-max-line-length: 100`
  and `footer-max-line-length: 100` rules matching CI enforcement
- `AGENTS.md` — added **Mandatory Pre-Push Rules** section covering:
  - `cargo fmt --all` before every commit
  - `scripts/quality-gates.sh` before every push
  - Commit body line wrapping at 100 chars with valid/invalid examples
  - Numbered change workflow with format + push steps

## How to activate the hooks

```bash
bash scripts/setup-hooks.sh
# optionally also install pre-commit framework:
pre-commit install
pre-commit install --hook-type commit-msg
```

## Motivation

PR #161 had two trivially preventable CI failures:

1. `CI / Format` — `cargo fmt --check` failed on `tools.rs` assert chains
2. `CI / Lint (Commits)` — `body-max-line-length` violated by auto-generated
   commit body from Jules

Both failures were caused by the contributing agent not running local
quality gates before pushing. This PR encodes those gates as executable
hooks and explicit agent instructions so they cannot be missed.

## Checklist

- [x] `cargo fmt --all -- --check` passes
- [x] `AGENTS.md` updated with mandatory pre-push rules
- [x] `commitlint.config.cjs` explicitly declares line-length rules
- [x] Hook installer script added for contributors
- [x] Commit template added for reference
