### PR TITLE
fix(security): handle poisoned mutex in MemoryBackend

### DIFF
--- a/crates/hybrid-storage-template/src/backends/mod.rs
+++ b/crates/hybrid-storage-template/src/backends/mod.rs
@@ -28,26 +28,24 @@ impl MemoryBackend {
 #[async_trait::async_trait]
 impl crate::Backend for MemoryBackend {
     async fn get(&self, key: &str) -> Result<Option<String>, StorageError> {
-        Ok(self.data.lock().unwrap().get(key).cloned())
+        let data = self.data.lock().map_err(|_| StorageError::Poisoned)?;
+        Ok(data.get(key).cloned())
     }
 
     async fn set(&self, key: &str, value: &str) -> Result<(), StorageError> {
-        self.data
-            .lock()
-            .unwrap()
-            .insert(key.to_string(), value.to_string());
+        let mut data = self.data.lock().map_err(|_| StorageError::Poisoned)?;
+        data.insert(key.to_string(), value.to_string());
         Ok(())
     }
 
     async fn delete(&self, key: &str) -> Result<bool, StorageError> {
-        Ok(self.data.lock().unwrap().remove(key).is_some())
+        let mut data = self.data.lock().map_err(|_| StorageError::Poisoned)?;
+        Ok(data.remove(key).is_some())
     }
 
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
-        Ok(self
-            .data
-            .lock()
-            .unwrap()
+        let data = self.data.lock().map_err(|_| StorageError::Poisoned)?;
+        Ok(data
             .keys()
             .filter(|k| k.starts_with(prefix))
             .cloned()

--- a/crates/hybrid-storage-template/src/backends/mod.rs
+++ b/crates/hybrid-storage-template/src/backends/mod.rs
@@ -28,24 +28,36 @@ impl MemoryBackend {
 #[async_trait::async_trait]
 impl crate::Backend for MemoryBackend {
     async fn get(&self, key: &str) -> Result<Option<String>, StorageError> {
-        let data = self.data.lock().map_err(|_| StorageError::Poisoned)?;
-        Ok(data.get(key).cloned())
+        Ok(self
+            .data
+            .lock()
+            .map_err(|_| StorageError::Poisoned)?
+            .get(key)
+            .cloned())
     }
 
     async fn set(&self, key: &str, value: &str) -> Result<(), StorageError> {
-        let mut data = self.data.lock().map_err(|_| StorageError::Poisoned)?;
-        data.insert(key.to_string(), value.to_string());
+        self.data
+            .lock()
+            .map_err(|_| StorageError::Poisoned)?
+            .insert(key.to_string(), value.to_string());
         Ok(())
     }
 
     async fn delete(&self, key: &str) -> Result<bool, StorageError> {
-        let mut data = self.data.lock().map_err(|_| StorageError::Poisoned)?;
-        Ok(data.remove(key).is_some())
+        Ok(self
+            .data
+            .lock()
+            .map_err(|_| StorageError::Poisoned)?
+            .remove(key)
+            .is_some())
     }
 
     async fn list_keys(&self, prefix: &str) -> Result<Vec<String>, StorageError> {
-        let data = self.data.lock().map_err(|_| StorageError::Poisoned)?;
-        Ok(data
+        Ok(self
+            .data
+            .lock()
+            .map_err(|_| StorageError::Poisoned)?
             .keys()
             .filter(|k| k.starts_with(prefix))
             .cloned()

--- a/crates/hybrid-storage-template/src/lib.rs
+++ b/crates/hybrid-storage-template/src/lib.rs
@@ -52,6 +52,10 @@ pub enum StorageError {
     /// Backend error.
     #[error("Backend error: {0}")]
     Backend(String),
+
+    /// Mutex poisoned (thread panicked while holding lock).
+    #[error("Internal lock poisoned")]
+    Poisoned,
 }
 
 /// Backend trait for storage implementations.


### PR DESCRIPTION
## Summary

Replace `Mutex::lock().unwrap()` with `lock().map_err()` in `hybrid-storage-template` `MemoryBackend` to prevent cascading panics when a thread panics while holding the lock.

## Changes

- Add `StorageError::Poisoned` variant for mutex poisoning errors
- Replace 4 `lock().unwrap()` calls with `lock().map_err(|_| StorageError::Poisoned)?`

## Why

If any thread panics while holding a `std::sync::Mutex`, the mutex becomes poisoned. All subsequent `lock().unwrap()` calls will then panic, causing a cascading failure across the entire application. Returning a proper error allows callers to handle the situation gracefully.