### PR TITLE
Update template version to 0.3.3 and refresh changelog

### DIFF
--- a/.template/CHANGELOG-TEMPLATE.md
+++ b/.template/CHANGELOG-TEMPLATE.md
@@ -33,6 +33,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.3] - 2026-06-20
+
+### Added
+
+- `triz-analysis` and `triz-solver` skills for Rust.
+- Draw.io architecture diagram in `.template/` directory.
+
+### Changed
+
+- Refined `SKILL.md` descriptions and formatting.
+
+### Fixed
+
+- Performance optimization for string sanitization and safe char checks in `sample-app`.
+
+---
+
 ## [0.3.2] - 2026-06-17
 
 ### Added
@@ -242,7 +259,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rust 2024 edition formatting (rustfmt.toml)
 - Clippy configuration (.clippy.toml)
 
-[Unreleased]: https://github.com/d-oit/rust-2026-template/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/d-oit/rust-2026-template/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/d-oit/rust-2026-template/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/d-oit/rust-2026-template/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/d-oit/rust-2026-template/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/d-oit/rust-2026-template/compare/v0.2.3...v0.3.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust 1.88+](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org)
 [![Mutation Testing](https://github.com/d-oit/rust-2026-template/actions/workflows/mutants.yml/badge.svg)](https://github.com/d-oit/rust-2026-template/actions/workflows/mutants.yml)
-[![Template Version](https://img.shields.io/badge/version-0.3.2-blue)](.template/CHANGELOG-TEMPLATE.md#032---2026-06-17)
+[![Template Version](https://img.shields.io/badge/version-0.3.3-blue)](.template/CHANGELOG-TEMPLATE.md#033---2026-06-20)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 <!-- cargo-sync-readme start -->


### PR DESCRIPTION
Incremented the template patch version from 0.3.2 to 0.3.3 based on git history. Updated .template/CHANGELOG-TEMPLATE.md with categorized summaries of new commits and adjusted the footer comparison links. Updated the 'Template Version' badge in README.md to reflect the new version and point to the corresponding changelog entry. Verified all changes with workspace tests and quality checks.

---
*PR created automatically by Jules for task [11872600667268837310](https://jules.google.com/task/11872600667268837310) started by @d-oit*