### PR TITLE
fix(security): implement safe loading and size limits for checkpoints

### DIFF
--- a/crates/checkpoint-template/src/lib.rs
+++ b/crates/checkpoint-template/src/lib.rs
@@ -35,7 +35,7 @@ use thiserror::Error;
 use tracing::info;
 
 pub use migration::MigrationError;
-use storage::FileStorage;
+use storage::{DEFAULT_MAX_CHECKPOINT_SIZE, FileStorage};
 
 /// Checkpoint header stored with each checkpoint file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -52,6 +52,26 @@ impl Default for CheckpointHeader {
             version: 1,
             created_at: SystemTime::UNIX_EPOCH,
             app_name: "unknown".to_string(),
+        }
+    }
+}
+
+/// Security configuration for checkpoints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CheckpointConfig {
+    /// Maximum size of a checkpoint file in bytes.
+    pub max_checkpoint_size: u64,
+    /// Maximum length of the app_name string in the header.
+    pub max_app_name_len: usize,
+}
+
+impl Default for CheckpointConfig {
+    fn default() -> Self {
+        Self {
+            max_checkpoint_size: DEFAULT_MAX_CHECKPOINT_SIZE,
+            // 256 bytes default limit
+            max_app_name_len: 256,
         }
     }
 }
@@ -105,15 +125,27 @@ pub trait Storable: Serialize + DeserializeOwned + Send + Sync + Clone + 'static
 /// Manages checkpoints with atomic save/load.
 pub struct CheckpointManager<T: Storable> {
     header: CheckpointHeader,
+    config: CheckpointConfig,
     storage: FileStorage,
     _marker: std::marker::PhantomData<T>,
 }
 
 impl<T: Storable> CheckpointManager<T> {
-    /// Create a new checkpoint manager.
+    /// Create a new checkpoint manager with default configuration.
     pub fn new(path: impl AsRef<Path>) -> Self {
         Self {
             header: CheckpointHeader::default(),
+            config: CheckpointConfig::default(),
+            storage: FileStorage::new(path),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Create a new checkpoint manager with custom configuration.
+    pub fn with_config(path: impl AsRef<Path>, config: CheckpointConfig) -> Self {
+        Self {
+            header: CheckpointHeader::default(),
+            config,
             storage: FileStorage::new(path),
             _marker: std::marker::PhantomData,
         }
@@ -138,22 +170,22 @@ impl<T: Storable> CheckpointManager<T> {
 
     /// Load state with migration support.
     pub async fn load(&self) -> Result<Option<T>, CheckpointError> {
-        // Security: Define a reasonable limit for checkpoint files and metadata.
-        const MAX_CHECKPOINT_SIZE: u64 = 10 * 1024 * 1024;
-        const MAX_APP_NAME_LEN: usize = 256;
-
-        let (header, payload) = match self.storage.load().await {
+        let (header, payload) = match self
+            .storage
+            .load_with_limit(self.config.max_checkpoint_size)
+            .await
+        {
             Ok(v) => v,
             Err(storage::StorageError::NotFound) => return Ok(None),
             Err(e) => return Err(CheckpointError::Storage(e)),
         };
 
         // Security (2026): Sanitize app_name to prevent log injection and resource exhaustion.
-        // Also check length.
-        if header.app_name.len() > MAX_APP_NAME_LEN {
+        if header.app_name.len() > self.config.max_app_name_len {
             return Err(CheckpointError::Serialization(format!(
-                "app_name too long: {} bytes (max {MAX_APP_NAME_LEN})",
-                header.app_name.len()
+                "app_name too long: {} bytes (max {})",
+                header.app_name.len(),
+                self.config.max_app_name_len
             )));
         }
 
@@ -173,7 +205,7 @@ impl<T: Storable> CheckpointManager<T> {
 
         // Security: Use bincode with a size limit to prevent resource exhaustion.
         use bincode::Options;
-        let options = bincode::options().with_limit(MAX_CHECKPOINT_SIZE);
+        let options = bincode::options().with_limit(self.config.max_checkpoint_size);
 
         let state = options
             .deserialize(&payload)
@@ -227,7 +259,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("too_large.ckpt");
 
-        // Create a file larger than 10MB
+        // Create a file larger than default 10MB
         let large_data = vec![0u8; 11 * 1024 * 1024];
         std::fs::write(&path, large_data).unwrap();
 
@@ -315,5 +347,42 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("control characters"));
+    }
+
+    #[tokio::test]
+    async fn test_with_custom_config() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("custom.ckpt");
+
+        let config = CheckpointConfig {
+            max_checkpoint_size: 100,
+            max_app_name_len: 5,
+        };
+
+        let manager = CheckpointManager::<TestState>::with_config(&path, config);
+
+        // App name too long for custom config
+        let header = CheckpointHeader {
+            version: 1,
+            created_at: SystemTime::UNIX_EPOCH,
+            app_name: "too_long".to_string(),
+        };
+        let state = TestState { value: 42 };
+
+        use bincode::Options;
+        let options = bincode::options();
+        let state_data = options.serialize(&state).unwrap();
+        let mut combined = options.serialize(&header).unwrap();
+        combined.extend_from_slice(&state_data);
+        std::fs::write(&path, combined).unwrap();
+
+        let result = manager.load().await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("app_name too long")
+        );
     }
 }

--- a/crates/checkpoint-template/src/lib.rs
+++ b/crates/checkpoint-template/src/lib.rs
@@ -39,6 +39,7 @@ use storage::FileStorage;
 
 /// Checkpoint header stored with each checkpoint file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct CheckpointHeader {
     pub version: u32,
     pub created_at: SystemTime,
@@ -123,8 +124,12 @@ impl<T: Storable> CheckpointManager<T> {
         self.header.version = T::version();
         self.header.created_at = SystemTime::now();
 
-        let data =
-            bincode::serialize(state).map_err(|e| CheckpointError::Serialization(e.to_string()))?;
+        use bincode::Options;
+        let options = bincode::options();
+
+        let data = options
+            .serialize(state)
+            .map_err(|e| CheckpointError::Serialization(e.to_string()))?;
 
         self.storage.save(&self.header, &data).await?;
         info!("Checkpoint saved (version {})", self.header.version);
@@ -133,10 +138,30 @@ impl<T: Storable> CheckpointManager<T> {
 
     /// Load state with migration support.
     pub async fn load(&self) -> Result<Option<T>, CheckpointError> {
-        let (header, data) = match self.storage.load().await {
+        // Security: Define a reasonable limit for checkpoint files and metadata.
+        const MAX_CHECKPOINT_SIZE: u64 = 10 * 1024 * 1024;
+        const MAX_APP_NAME_LEN: usize = 256;
+
+        let (header, payload) = match self.storage.load().await {
             Ok(v) => v,
-            Err(_) => return Ok(None),
+            Err(storage::StorageError::NotFound) => return Ok(None),
+            Err(e) => return Err(CheckpointError::Storage(e)),
         };
+
+        // Security (2026): Sanitize app_name to prevent log injection and resource exhaustion.
+        // Also check length.
+        if header.app_name.len() > MAX_APP_NAME_LEN {
+            return Err(CheckpointError::Serialization(format!(
+                "app_name too long: {} bytes (max {MAX_APP_NAME_LEN})",
+                header.app_name.len()
+            )));
+        }
+
+        if header.app_name.chars().any(|c| c.is_control()) {
+            return Err(CheckpointError::Serialization(
+                "app_name contains control characters".to_string(),
+            ));
+        }
 
         // Handle version mismatch
         if header.version != T::version() {
@@ -146,7 +171,12 @@ impl<T: Storable> CheckpointManager<T> {
             });
         }
 
-        let state = bincode::deserialize(&data)
+        // Security: Use bincode with a size limit to prevent resource exhaustion.
+        use bincode::Options;
+        let options = bincode::options().with_limit(MAX_CHECKPOINT_SIZE);
+
+        let state = options
+            .deserialize(&payload)
             .map_err(|e| CheckpointError::Serialization(e.to_string()))?;
 
         Ok(Some(state))
@@ -190,5 +220,100 @@ mod tests {
         let manager = CheckpointManager::<TestState>::new(&path);
         let result = manager.load().await.unwrap();
         assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_load_config_too_large() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("too_large.ckpt");
+
+        // Create a file larger than 10MB
+        let large_data = vec![0u8; 11 * 1024 * 1024];
+        std::fs::write(&path, large_data).unwrap();
+
+        let manager = CheckpointManager::<TestState>::new(&path);
+        let result = manager.load().await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            CheckpointError::Storage(storage::StorageError::TooLarge(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_load_config_invalid_type() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("directory.ckpt");
+        std::fs::create_dir(&path).unwrap();
+
+        let manager = CheckpointManager::<TestState>::new(&path);
+        let result = manager.load().await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err,
+            CheckpointError::Storage(storage::StorageError::InvalidType)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_load_config_app_name_too_long() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("long_app_name.ckpt");
+
+        let header = CheckpointHeader {
+            version: 1,
+            created_at: SystemTime::UNIX_EPOCH,
+            app_name: "a".repeat(257),
+        };
+        let state = TestState { value: 42 };
+
+        use bincode::Options;
+        let options = bincode::options();
+        let state_data = options.serialize(&state).unwrap();
+
+        let mut combined = options.serialize(&header).unwrap();
+        combined.extend_from_slice(&state_data);
+
+        std::fs::write(&path, combined).unwrap();
+
+        let manager = CheckpointManager::<TestState>::new(&path);
+        let result = manager.load().await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("app_name too long"));
+    }
+
+    #[tokio::test]
+    async fn test_load_config_app_name_control_chars() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("control_chars.ckpt");
+
+        let header = CheckpointHeader {
+            version: 1,
+            created_at: SystemTime::UNIX_EPOCH,
+            app_name: "test\napp".to_string(),
+        };
+        let state = TestState { value: 42 };
+
+        use bincode::Options;
+        let options = bincode::options();
+        let state_data = options.serialize(&state).unwrap();
+
+        let mut combined = options.serialize(&header).unwrap();
+        combined.extend_from_slice(&state_data);
+
+        std::fs::write(&path, combined).unwrap();
+
+        let manager = CheckpointManager::<TestState>::new(&path);
+        let result = manager.load().await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("control characters"));
     }
 }

--- a/crates/checkpoint-template/src/storage.rs
+++ b/crates/checkpoint-template/src/storage.rs
@@ -101,7 +101,10 @@ impl FileStorage {
 
         // Security (2026): Use a capacity-limited reader to prevent OOM
         // if the file grows between metadata check and read (though rare on handles).
-        let mut data = Vec::with_capacity(file_size as usize);
+        let data_capacity =
+            usize::try_from(file_size).map_err(|_| StorageError::TooLarge(file_size))?;
+        let mut data = Vec::with_capacity(data_capacity);
+
         use tokio::io::AsyncReadExt;
         let mut reader = file.take(MAX_CHECKPOINT_SIZE);
         reader
@@ -120,7 +123,9 @@ impl FileStorage {
             .deserialize_from(&mut cursor)
             .map_err(|_| StorageError::Serialization)?;
 
-        let payload = data[cursor.position() as usize..].to_vec();
+        let payload_start =
+            usize::try_from(cursor.position()).map_err(|_| StorageError::Serialization)?;
+        let payload = data[payload_start..].to_vec();
         Ok((header, payload))
     }
 }

--- a/crates/checkpoint-template/src/storage.rs
+++ b/crates/checkpoint-template/src/storage.rs
@@ -3,7 +3,6 @@
 use super::CheckpointHeader;
 pub use super::MigrationError;
 use std::path::PathBuf;
-use std::time::SystemTime;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
@@ -21,6 +20,14 @@ pub enum StorageError {
     /// Checkpoint not found.
     #[error("Checkpoint not found")]
     NotFound,
+
+    /// Checkpoint file too large.
+    #[error("Checkpoint too large: {0} bytes")]
+    TooLarge(u64),
+
+    /// Invalid file type.
+    #[error("Invalid file type")]
+    InvalidType,
 }
 
 /// File-based checkpoint storage with atomic writes.
@@ -41,12 +48,15 @@ impl FileStorage {
         let temp_path = self.path.with_extension("tmp");
         let final_path = self.path.with_extension("ckpt");
 
-        let combined: Vec<u8> =
-            bincode::serialize(&(header.version, header.created_at, header.app_name.clone()))
-                .map_err(|_| StorageError::Serialization)?
-                .into_iter()
-                .chain(data.iter().copied())
-                .collect();
+        use bincode::Options;
+        let options = bincode::options();
+
+        let combined: Vec<u8> = options
+            .serialize(header)
+            .map_err(|_| StorageError::Serialization)?
+            .into_iter()
+            .chain(data.iter().copied())
+            .collect();
 
         let mut file = fs::File::create(&temp_path)
             .await
@@ -64,7 +74,10 @@ impl FileStorage {
     /// Load checkpoint data.
     pub async fn load(&self) -> Result<(CheckpointHeader, Vec<u8>), StorageError> {
         let final_path = self.path.with_extension("ckpt");
-        let data = fs::read(&final_path).await.map_err(|e| {
+
+        // Security (2026): Open file FIRST to avoid TOCTOU (Time-of-Check to Time-of-Use)
+        // vulnerabilities. Using the file handle for subsequent metadata checks.
+        let file = fs::File::open(&final_path).await.map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
                 StorageError::NotFound
             } else {
@@ -72,17 +85,42 @@ impl FileStorage {
             }
         })?;
 
+        let metadata = file.metadata().await.map_err(StorageError::Io)?;
+
+        if !metadata.is_file() {
+            return Err(StorageError::InvalidType);
+        }
+
+        let file_size = metadata.len();
+        // Security: Define a reasonable limit for checkpoint files.
+        // We use 10MB as a default limit.
+        const MAX_CHECKPOINT_SIZE: u64 = 10 * 1024 * 1024;
+        if file_size > MAX_CHECKPOINT_SIZE {
+            return Err(StorageError::TooLarge(file_size));
+        }
+
+        // Security (2026): Use a capacity-limited reader to prevent OOM
+        // if the file grows between metadata check and read (though rare on handles).
+        let mut data = Vec::with_capacity(file_size as usize);
+        use tokio::io::AsyncReadExt;
+        let mut reader = file.take(MAX_CHECKPOINT_SIZE);
+        reader
+            .read_to_end(&mut data)
+            .await
+            .map_err(StorageError::Io)?;
+
         let mut cursor = std::io::Cursor::new(&data);
-        let (version, created_at, app_name): (u32, SystemTime, String) =
-            bincode::deserialize_from(&mut cursor).map_err(|_| StorageError::Serialization)?;
+        // Security: Use bincode with a size limit to prevent resource exhaustion.
+        use bincode::Options;
+        let options = bincode::options()
+            .with_limit(MAX_CHECKPOINT_SIZE)
+            .allow_trailing_bytes();
 
-        let header = CheckpointHeader {
-            version,
-            created_at,
-            app_name,
-        };
+        let header: CheckpointHeader = options
+            .deserialize_from(&mut cursor)
+            .map_err(|_| StorageError::Serialization)?;
 
-        let payload = data[usize::try_from(cursor.position()).unwrap_or(0)..].to_vec();
+        let payload = data[cursor.position() as usize..].to_vec();
         Ok((header, payload))
     }
 }

--- a/crates/checkpoint-template/src/storage.rs
+++ b/crates/checkpoint-template/src/storage.rs
@@ -6,6 +6,9 @@ use std::path::PathBuf;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
+/// Default maximum size for a checkpoint file (10MB).
+pub const DEFAULT_MAX_CHECKPOINT_SIZE: u64 = 10 * 1024 * 1024;
+
 /// Storage error types.
 #[derive(Debug, thiserror::Error)]
 pub enum StorageError {
@@ -71,8 +74,11 @@ impl FileStorage {
         Ok(())
     }
 
-    /// Load checkpoint data.
-    pub async fn load(&self) -> Result<(CheckpointHeader, Vec<u8>), StorageError> {
+    /// Load checkpoint data with a specific size limit.
+    pub async fn load_with_limit(
+        &self,
+        max_size: u64,
+    ) -> Result<(CheckpointHeader, Vec<u8>), StorageError> {
         let final_path = self.path.with_extension("ckpt");
 
         // Security (2026): Open file FIRST to avoid TOCTOU (Time-of-Check to Time-of-Use)
@@ -92,10 +98,7 @@ impl FileStorage {
         }
 
         let file_size = metadata.len();
-        // Security: Define a reasonable limit for checkpoint files.
-        // We use 10MB as a default limit.
-        const MAX_CHECKPOINT_SIZE: u64 = 10 * 1024 * 1024;
-        if file_size > MAX_CHECKPOINT_SIZE {
+        if file_size > max_size {
             return Err(StorageError::TooLarge(file_size));
         }
 
@@ -106,7 +109,7 @@ impl FileStorage {
         let mut data = Vec::with_capacity(data_capacity);
 
         use tokio::io::AsyncReadExt;
-        let mut reader = file.take(MAX_CHECKPOINT_SIZE);
+        let mut reader = file.take(max_size);
         reader
             .read_to_end(&mut data)
             .await
@@ -116,7 +119,7 @@ impl FileStorage {
         // Security: Use bincode with a size limit to prevent resource exhaustion.
         use bincode::Options;
         let options = bincode::options()
-            .with_limit(MAX_CHECKPOINT_SIZE)
+            .with_limit(max_size)
             .allow_trailing_bytes();
 
         let header: CheckpointHeader = options
@@ -127,6 +130,11 @@ impl FileStorage {
             usize::try_from(cursor.position()).map_err(|_| StorageError::Serialization)?;
         let payload = data[payload_start..].to_vec();
         Ok((header, payload))
+    }
+
+    /// Load checkpoint data using default limit (10MB).
+    pub async fn load(&self) -> Result<(CheckpointHeader, Vec<u8>), StorageError> {
+        self.load_with_limit(DEFAULT_MAX_CHECKPOINT_SIZE).await
     }
 }
 


### PR DESCRIPTION
Hardened the `checkpoint-template` crate against resource exhaustion (OOM/DoS) and TOCTOU vulnerabilities. 

Key improvements:
- Implemented a 10MB file size limit and 256-byte app_name limit.
- Mitigated TOCTOU by opening files before metadata validation.
- Enforced safe deserialization using `bincode` size limits.
- Sanitized `app_name` against control characters to prevent log injection.
- Added 4 new security-focused tests to verify boundaries.
- Ensured compliance with 2026 security best practices.

---
*PR created automatically by Jules for task [17983064730385128341](https://jules.google.com/task/17983064730385128341) started by @d-oit*