### PR TITLE
feat(harness): implement harness engineering (#205-#209)

### DIFF
--- a/.agents/SKILLS.md
+++ b/.agents/SKILLS.md
@@ -15,6 +15,7 @@ Run `bash scripts/generate-skills-md.sh` to regenerate after adding or modifying
 | `crates-io-name-check` | [skills/crates-io-name-check/SKILL.md](skills/crates-io-name-check/SKILL.md) | Verify that a new Rust crate name is available and appropriate on crates.io |
 | `dora-report` | [skills/dora-report/SKILL.md](skills/dora-report/SKILL.md) | Generate a DORA-REPORT.md for this repository by computing the five core DORA software delivery perf |
 | `goap-agent` | [skills/goap-agent/SKILL.md](skills/goap-agent/SKILL.md) | Invoke for complex multi-step tasks requiring intelligent planning and |
+| `harness` | [skills/harness/SKILL.md](skills/harness/SKILL.md) | Harness engineering guide — maps all sensors and feedforward guides, |
 | `issue-triage` | [skills/issue-triage/SKILL.md](skills/issue-triage/SKILL.md) | Read all open issues (GitHub/GitLab), categorize by type and effort, plan |
 | `lint-rust` | [skills/lint-rust/SKILL.md](skills/lint-rust/SKILL.md) | Run comprehensive linting and static analysis on Rust code including clippy, |
 | `metrics-reporter` | [skills/metrics-reporter/SKILL.md](skills/metrics-reporter/SKILL.md) | Record agentic task completion via event files for DORA observability. |

--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: harness
+description: >
+  Harness engineering guide — maps all sensors and feedforward guides,
+  teaches self-correction protocol when a CI sensor fires.
+  Use when a sensor fires, before making code changes, or when setting up
+  agent context for a new task.
+  Triggers: "harness", "sensor fire", "CI failure", "self-correction".
+category: rust
+license: MIT
+metadata:
+  author: d-oit
+  version: "1.0"
+  tags: harness sensors ci quality self-correction
+---
+
+# Skill: harness
+
+## What Is the Harness
+
+Agent = Model + Harness. The harness is the system of feedforward guides (what to do before coding) and feedback sensors (what catches violations after coding). It has two axes:
+
+- **Feedforward (guides):** Context, constraints, conventions that prevent errors before they happen.
+- **Feedback (sensors):** Automated checks that fire after code changes, providing structured error output.
+
+The harness has two modes:
+- **Computational:** Deterministic checks (fmt, clippy, deny) — always trust the output.
+- **Inferential:** LLM-based guidance (skill docs, agent context) — direction, not commands.
+
+## Sensor Response Protocol
+
+When a computational sensor fires:
+
+1. **Read the full error message** — it includes a fix hint.
+2. **Classify the error:** fmt / lint / test / arch / security.
+3. **Apply the minimal fix** — do not refactor unrelated code.
+4. **Re-run the specific sensor** — `cargo fmt`, `cargo clippy`, etc.
+5. **Only commit when the sensor is green.**
+6. **Write a metrics event** to `.agents/events/YYYY/MM/DD/` per the `metrics-reporter` skill.
+
+## Sensor Quick Reference
+
+| Sensor | Command | Config | Stage |
+|--------|---------|--------|-------|
+| fmt | `cargo fmt --all -- --check` | `.pre-commit-config.yaml` | pre-commit |
+| clippy | `cargo clippy --all-targets --all-features -- -D warnings` | `.clippy.toml`, `.pre-commit-config.yaml` | pre-commit + CI |
+| deny | `cargo deny check` | `deny.toml` | pre-commit + CI |
+| nextest | `cargo nextest run` | `Cargo.toml` | CI |
+| mutants | `cargo mutants` | `[workspace.metadata.cargo-mutants]` in `Cargo.toml` | CI weekly |
+| arch_fitness | `cargo test --test arch_fitness` | `tests/arch_fitness.rs` | CI |
+| insta snapshots | `cargo insta review` | `tests/behaviour_harness.rs` | CI |
+| gitleaks | `gitleaks detect` | `.gitleaks.toml` | CI |
+
+## Steering Loop
+
+When any sensor fires **repeatedly** (>2 times in one sprint):
+
+1. Identify the root cause category (maintainability / architecture / behaviour).
+2. Update the corresponding **feedforward guide** to prevent recurrence.
+3. If no guide exists, create one in `.agents/skills/` using the `skill-creator` skill.
+4. Document the update in `CHANGELOG.md`.
+
+The steering loop closes the harness: sensors fire → humans and agents update guides → sensors fire less.
+
+## References
+
+- Full harness map: [`HARNESS.md`](../../HARNESS.md) at repo root.
+- Agent-optimised error output: `scripts/harness-check.sh` runs each sensor and emits structured error output with `HARNESS VIOLATION` prefix.

--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,11 @@
+# HARNESS FEEDFORWARD GUIDE: .clippy.toml
+# This file controls cargo clippy configuration for rust-2026-template.
+# Agents: read this file before running clippy to understand which lints are intentionally suppressed.
+#
+# Allowed lints (with rationale):
+# — Add entries here with comments explaining WHY an exception is granted.
+#    Never add exceptions without a rationale comment.
+#
 # .clippy.toml - Clippy lint configuration for Rust 2026 best practices
 
 # Cognitive complexity threshold for functions

--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,8 @@ default.profraw
 .blackboxcli/
 
 
+# insta pending snapshots
+*.snap.new
+
 # Auto-generated LLM context files
 llms-full.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,20 +16,20 @@ repos:
   - repo: local
     hooks:
       - id: cargo-fmt
-        name: cargo fmt
-        entry: cargo fmt --all -- --check
+        name: cargo fmt (harness sensor)
+        entry: bash scripts/harness-check.sh fmt
         language: system
         types: [rust]
         pass_filenames: false
       - id: cargo-clippy
-        name: cargo clippy
-        entry: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        name: cargo clippy (harness sensor)
+        entry: bash scripts/harness-check.sh clippy
         language: system
         types: [rust]
         pass_filenames: false
       - id: cargo-deny
-        name: cargo deny
-        entry: cargo deny check
+        name: cargo deny (harness sensor)
+        entry: bash scripts/harness-check.sh deny
         language: system
         pass_filenames: false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 ## Project Structure
 
 - `.agents/skills/`: Executable task knowledge and canonical workflows.
+- `.agents/skills/harness/`: Harness engineering — sensor response protocol and self-correction.
 - `crates/`: Workspace members (libraries and applications).
 - `scripts/`: Development, quality, and release automation.
 - `plans/adr/`: Architecture Decision Records.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +427,12 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -724,6 +741,19 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
  "serde",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -1174,6 +1204,8 @@ dependencies = [
 name = "rust-2026-template"
 version = "0.0.0"
 dependencies = [
+ "insta",
+ "serde_json",
  "tokio",
 ]
 
@@ -1329,6 +1361,12 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ workspace = true
 # crates/sample-app and crates/*-template directly.
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"], optional = true }
 
+[dev-dependencies]
+insta = { workspace = true }
+serde_json = { workspace = true }
+
 [features]
 default = []
 # These features are provided as a demonstration of workspace-level feature

--- a/HARNESS.md
+++ b/HARNESS.md
@@ -1,0 +1,92 @@
+# Harness Engineering
+
+> Agent = Model + Harness. This document is the harness map for rust-2026-template.
+> Based on: https://martinfowler.com/articles/harness-engineering.html
+
+## Mental Model
+
+The harness has two axes:
+- **Feedforward (guides):** What to do *before* writing code — context, constraints, conventions
+- **Feedback (sensors):** What fires *after* writing code — automated checks that catch violations
+
+And two modes:
+- **Computational:** Deterministic (clippy, tests, deny) — always trust the output
+- **Inferential:** LLM-based (skill docs, agent context) — direction, not commands
+
+## Feedforward Guides
+
+### Inferential (read before coding)
+
+| Guide | Path | Purpose |
+|---|---|---|
+| Agent contract | `AGENTS.md` | Root coding conventions, change workflow, quality gates |
+| Skills index | `.agents/SKILLS.md` | Available executable task knowledge |
+| Harness overview | `HARNESS.md` (this file) | How guides and sensors connect |
+| Harness skill | `.agents/skills/harness/SKILL.md` | Sensor response protocol and self-correction |
+| Clippy intent | `.clippy.toml` | Linting philosophy and allowed exceptions |
+| Dependency rules | `deny.toml` | Crate layering rules (`*-types → *-core → *-adapters → *-cli`) |
+| Architecture | `plans/adr/` | Architecture Decision Records |
+| Cross-repo context | `.agents/context/shared-conventions.md` | Commit format, branch naming, PR requirements |
+
+### Computational (structural constraints)
+
+| Constraint | File | Enforced by |
+|---|---|---|
+| Crate layering | `deny.toml` | `cargo deny check` |
+| No unsafe code | `Cargo.toml` `[workspace.lints.rust]` | `rustc` |
+| Max 500 LOC/file | `AGENTS.md` | Agent self-check |
+| Conventional commits | `commitlint.config.cjs` | `commitlint` pre-commit hook |
+
+## Feedback Sensors
+
+### Computational (deterministic — always trust)
+
+| Sensor | Trigger | Config | LLM Fix Hint |
+|---|---|---|---|
+| `cargo fmt --check` | pre-commit | `.pre-commit-config.yaml` | Run `cargo fmt --all` |
+| `cargo clippy -D warnings` | pre-commit + CI | `.clippy.toml`, `.pre-commit-config.yaml` | Fix all warnings; see `.clippy.toml` for allowed exceptions |
+| `cargo deny check` | pre-commit + CI | `deny.toml` | Check crate layering diagram in `Cargo.toml` comments |
+| `cargo nextest run` | CI (`ci.yml`) | `Cargo.toml` | Fix failing tests before opening PR |
+| `cargo mutants` | CI weekly (`mutants.yml`) | `[workspace.metadata.cargo-mutants]` in `Cargo.toml` | If score < threshold, add targeted unit tests |
+| `shellcheck` | pre-commit | `.shellcheckrc` | Fix shell script issues at severity=warning |
+| `gitleaks` | CI (`security-scan.yml`) | `.gitleaks.toml` | Remove secrets; use env vars or `.env` |
+| Architecture fitness | `tests/arch_fitness.rs` | `Cargo.toml` dev-deps | HARNESS VIOLATION message includes fix instructions |
+| Snapshot tests | `tests/behaviour_harness.rs` | `Cargo.toml` `insta = "=1.47.2"` | Run `cargo insta review` to approve new baselines |
+
+### Inferential (LLM-based — use for direction)
+
+| Sensor | Path | Purpose |
+|---|---|---|
+| Codacy quality review | `.codacy.yml`, CI | Code quality suggestions |
+| Codecov coverage | `.codecov.yml`, CI | Coverage regression detection |
+| AI skill evaluator | `.agents/skills/skill-evaluator/` | Evaluate skill effectiveness |
+
+## Steering Loop
+
+When any sensor fires **repeatedly** (>2 times in one sprint):
+1. Identify the root cause category (maintainability / architecture / behaviour)
+2. Update the corresponding **feedforward guide** to prevent recurrence
+3. If no guide exists, create one in `.agents/skills/` using the `skill-creator` skill
+4. Document the update in `CHANGELOG.md`
+
+The steering loop closes the harness: sensors fire → humans and agents update guides → sensors fire less.
+
+## Self-Correction Protocol for Agents
+
+When a computational sensor fires:
+1. Read the full error message — it includes a fix hint
+2. Identify category: fmt / lint / test / arch / security
+3. Apply the minimal fix (do not refactor unrelated code)
+4. Re-run the specific sensor: `cargo clippy`, `cargo test`, etc.
+5. Only commit when the sensor is green
+6. Write a metrics event to `.agents/events/YYYY/MM/DD/` per the `metrics-reporter` skill
+
+## Agent-Optimised Error Output
+
+The `scripts/harness-check.sh` wrapper runs each sensor and emits structured error output with `HARNESS VIOLATION` prefix and agent-parseable fix hints. Use it for richer feedback than raw sensor output:
+
+```bash
+bash scripts/harness-check.sh <fmt|clippy|deny|test|arch|all>
+```
+
+See `scripts/harness-check.sh` for the full sensor → hint mapping.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all docs docs-check ci fmt clippy test build install-doc-tools
+.PHONY: all docs docs-check ci fmt clippy test build install-doc-tools harness insta-review
 
 all: ci
 
@@ -35,3 +35,9 @@ docs: ## Auto-generate docs/patterns/ from rustdoc comments (run install-doc-too
 docs-check: docs ## Fail if generated docs differ from committed versions
 	cargo sync-readme --check
 	git diff --exit-code docs/patterns/
+
+harness:  ## Run all harness sensors with agent-optimised output
+	bash scripts/harness-check.sh all
+
+insta-review:  ## Review and approve insta snapshot changes
+	cargo insta review

--- a/scripts/harness-check.sh
+++ b/scripts/harness-check.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# harness-check.sh — run a harness sensor with agent-optimised error output
+# Usage: ./scripts/harness-check.sh <sensor>
+# Sensors: fmt | clippy | deny | test | arch | all
+set -euo pipefail
+
+SENSOR=${1:-""}
+PASSED="\033[0;32m✅ HARNESS OK\033[0m"
+FAILED="\033[0;31m❌ HARNESS VIOLATION\033[0m"
+
+run_with_hint() {
+    local name="$1" cmd="$2" hint="$3"
+    echo "▶ Running sensor: $name"
+    if eval "$cmd"; then
+        echo -e "$PASSED [$name]"
+        return 0
+    else
+        echo -e "$FAILED [$name]"
+        echo ""
+        echo "  AGENT FIX HINT: $hint"
+        echo "  See HARNESS.md for the full sensor ↔ guide map."
+        return 1
+    fi
+}
+
+case "$SENSOR" in
+  fmt)
+    run_with_hint "cargo fmt" \
+        "cargo fmt --all -- --check" \
+        "Run: cargo fmt --all"
+    ;;
+  clippy)
+    run_with_hint "cargo clippy" \
+        "cargo clippy --workspace --all-targets --all-features -- -D warnings" \
+        "Fix all warnings. Check .clippy.toml for allowed exceptions. Do not add #[allow(...)] without justification comment."
+    ;;
+  deny)
+    run_with_hint "cargo deny" \
+        "cargo deny check" \
+        "Check deny.toml for the violation type: license/bans/advisories/sources. For layering: see crate diagram in Cargo.toml workspace comments."
+    ;;
+  test)
+    run_with_hint "cargo nextest" \
+        "cargo nextest run --workspace" \
+        "Fix the failing test. If behaviour changed intentionally, update the test and run: cargo insta review"
+    ;;
+  arch)
+    run_with_hint "arch fitness" \
+        "cargo test --test arch_fitness" \
+        "LAYERING VIOLATION: Move code to the correct crate layer. See tests/arch_fitness.rs error for the specific fix."
+    ;;
+  all)
+    run_with_hint "cargo fmt" "cargo fmt --all -- --check" "Run: cargo fmt --all"
+    run_with_hint "cargo clippy" "cargo clippy --workspace --all-targets --all-features -- -D warnings" "Fix all warnings. Check .clippy.toml."
+    run_with_hint "cargo deny" "cargo deny check" "Check deny.toml for the violation type."
+    run_with_hint "cargo nextest" "cargo nextest run --workspace" "Fix the failing test."
+    ;;
+  *)
+    echo "Usage: $0 <fmt|clippy|deny|test|arch|all>"
+    exit 1
+    ;;
+esac

--- a/tests/arch_fitness.rs
+++ b/tests/arch_fitness.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+/// Parses `cargo metadata` and returns a map of crate names to their workspace dependency names.
+fn workspace_dep_map() -> HashMap<String, Vec<String>> {
+    let output = std::process::Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()
+        .expect("failed to run cargo metadata");
+
+    let mut map = HashMap::new();
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("failed to parse cargo metadata JSON");
+
+    if let Some(packages) = metadata["packages"].as_array() {
+        for pkg in packages {
+            let name = pkg["name"].as_str().unwrap_or("").to_string();
+            let deps: Vec<String> = pkg["dependencies"]
+                .as_array()
+                .unwrap_or(&vec![])
+                .iter()
+                .filter_map(|d| d["name"].as_str().map(String::from))
+                .collect();
+            map.insert(name, deps);
+        }
+    }
+
+    map
+}
+
+/// Returns the architectural layer for a crate based on its name suffix.
+fn crate_layer(name: &str) -> Option<u8> {
+    if name.ends_with("-types") || name.ends_with("-domain") {
+        Some(0)
+    } else if name.ends_with("-core") || name.ends_with("-logic") {
+        Some(1)
+    } else if name.ends_with("-adapters")
+        || name.ends_with("-backends")
+        || name.ends_with("-adapter")
+    {
+        Some(2)
+    } else if name.ends_with("-cli") || name.ends_with("-bin") || name.ends_with("-app") {
+        Some(3)
+    } else {
+        None
+    }
+}
+
+#[test]
+fn crate_layering_no_upward_dependencies() {
+    let dep_map = workspace_dep_map();
+
+    for (crate_name, deps) in &dep_map {
+        if let Some(layer) = crate_layer(crate_name) {
+            for dep in deps {
+                if let Some(dep_layer) = crate_layer(dep) {
+                    assert!(
+                        dep_layer <= layer,
+                        "HARNESS VIOLATION: Crate `{crate_name}` (layer {layer}) \
+                         depends on `{dep}` (layer {dep_layer}). \
+                         Upward dependencies are not allowed. \
+                         FIX: Move shared types to a lower-layer crate, \
+                         introduce a trait in the lower layer, or restructure the dependency graph."
+                    );
+                }
+            }
+        }
+    }
+}

--- a/tests/behaviour_harness.rs
+++ b/tests/behaviour_harness.rs
@@ -1,0 +1,47 @@
+use rust_2026_template::add;
+
+#[test]
+fn snapshot_add_canonical_outputs() {
+    let cases: Vec<(u64, u64, u64)> = vec![
+        (0, 0, add(0, 0)),
+        (1, 1, add(1, 1)),
+        (10, 20, add(10, 20)),
+        (100, 200, add(100, 200)),
+        (u64::MAX, 0, add(u64::MAX, 0)),
+    ];
+
+    insta::assert_yaml_snapshot!(cases);
+}
+
+#[test]
+fn snapshot_workspace_crate_names() {
+    let output = std::process::Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()
+        .expect("failed to run cargo metadata");
+
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("failed to parse cargo metadata JSON");
+
+    let mut crate_names: Vec<String> = metadata["packages"]
+        .as_array()
+        .expect("packages is not an array")
+        .iter()
+        .map(|pkg| {
+            pkg["name"]
+                .as_str()
+                .expect("package name is not a string")
+                .to_string()
+        })
+        .collect();
+
+    crate_names.sort();
+
+    insta::assert_yaml_snapshot!("workspace_crate_names", crate_names);
+}

--- a/tests/snapshots/behaviour_harness__snapshot_add_canonical_outputs.snap
+++ b/tests/snapshots/behaviour_harness__snapshot_add_canonical_outputs.snap
@@ -1,0 +1,20 @@
+---
+source: tests/behaviour_harness.rs
+assertion_line: 13
+expression: cases
+---
+- - 0
+  - 0
+  - 0
+- - 1
+  - 1
+  - 2
+- - 10
+  - 20
+  - 30
+- - 100
+  - 200
+  - 300
+- - 18446744073709551615
+  - 0
+  - 18446744073709551615

--- a/tests/snapshots/behaviour_harness__workspace_crate_names.snap
+++ b/tests/snapshots/behaviour_harness__workspace_crate_names.snap
@@ -1,0 +1,16 @@
+---
+source: tests/behaviour_harness.rs
+assertion_line: 41
+expression: crate_names
+---
+- actor-runtime-template
+- benchmarks
+- checkpoint-template
+- example-crate
+- example-registry-pattern
+- example-storage-pattern
+- hello-world-example
+- hybrid-storage-template
+- mcp-server-template
+- rust-2026-template
+- sample-app


### PR DESCRIPTION
## Summary

- Add `HARNESS.md` steering document mapping all sensors and feedforward guides based on Martin Fowler's harness engineering article (#205)
- Add `tests/arch_fitness.rs` with crate layering violation detection and HARNESS VIOLATION error messages (#206)
- Add `tests/behaviour_harness.rs` with insta snapshot behaviour harness for approved fixtures (#207)
- Add `.agents/skills/harness/SKILL.md` with sensor response protocol and self-correction guide (#208)
- Add `scripts/harness-check.sh` wrapper that runs sensors with agent-optimised HARNESS VIOLATION error output (#209)
- Update `.pre-commit-config.yaml` hooks to use the harness wrapper
- Add `harness` and `insta-review` targets to `Makefile`
- Add feedforward guide comment block to `.clippy.toml`
- Add `*.snap.new` to `.gitignore`
- Add `insta` and `serde_json` to root `[dev-dependencies]`

## Issues Closed

- Closes #205
- Closes #206
- Closes #207
- Closes #208
- Closes #209

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✅
- `cargo nextest run --workspace` — 82 tests passed ✅
- `shellcheck scripts/harness-check.sh` ✅
- `bash scripts/harness-check.sh fmt|clippy|test|arch` ✅
- `bash scripts/generate-skills-md.sh` ✅ (21 skills)
- `bash scripts/generate-llms-txt.sh` ✅