### PR TITLE
chore(ci): parameterize cache-on-failure per job

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -11,6 +11,13 @@ inputs:
     description: Additional rustup components to install
     required: false
     default: ""
+  cache-on-failure:
+    description: >-
+      Whether `Swatinem/rust-cache` should save the cache when the workflow
+      fails. Default `true` (safe for most jobs). Set to `false` for jobs
+      that can poison the cache with stale `.fingerprint/` lint metadata.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -26,7 +33,4 @@ runs:
 
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
       with:
-        # Don't save the cache when the workflow fails — otherwise a Clippy
-        # failure leaves phantom `.fingerprint/` metadata in `target/` that
-        # gets re-uploaded, replaying stale diagnostics on the next PR.
-        cache-on-failure: false
+        cache-on-failure: ${{ inputs.cache-on-failure }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,11 @@ jobs:
         with:
           components: clippy
       - uses: ./.github/actions/setup-rust
+        # Clippy is the only job where a failed run can poison the cache
+        # with stale `.fingerprint/` metadata. Disable cache-on-failure
+        # only for this job; other jobs keep the safe `true` default.
+        with:
+          cache-on-failure: false
       # `cargo clean -p` only removes compiled artifacts, NOT the
       # `.fingerprint/` directory that Rust 1.66+ uses to cache and replay
       # clippy diagnostics for example/test targets that have been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- for changes in existing functionality.
+- `setup-rust` composite action now exposes a `cache-on-failure` input
+  (default `true`); the Clippy job in CI overrides it to `false` so a
+  failed run cannot re-upload poisoned `.fingerprint/` metadata to the
+  rust-cache. Other jobs (Format, Test, Security, deny, Benchmarks, MSRV,
+  Version-check) keep the safe `true` default.
+- `examples/roast-scorer.rs` now uses `Result<(), Box<dyn std::error::Error>>`-
+  returning `main` with `?`-propagation (no `.expect()` calls) and
+  `#![allow(missing_docs)]`, replacing the pre-merge version on
+  `origin/main` that violated `clippy::expect_used` and `missing_docs`
+  under `-D warnings`. Behaviour for callers invoking
+  `cargo run --example roast-scorer` is unchanged.
 
 ### Deprecated
 


### PR DESCRIPTION
## Summary

Move the `cache-on-failure` setting from a hardcoded `false` in the `setup-rust` composite action to an **input** (default `true`). Only the **clippy** job in `ci.yml` overrides the input to `false`, because clippy is the only job where a failed run can poison the rust-cache with stale `.fingerprint/` lint metadata.

## Changes

- `.github/actions/setup-rust/action.yml`: new `cache-on-failure` input (default `"true"`); passed through to `Swatinem/rust-cache`.
- `.github/workflows/ci.yml`: clippy job overrides `cache-on-failure: false`; all 11 other jobs (Format, Test, Security, deny, Benchmarks, MSRV, Version-check, etc.) keep the safe `true` default.
- `CHANGELOG.md`: `### Changed` entries under `[Unreleased]`.

## Why

PR #221 had a global `cache-on-failure: false` in `setup-rust/action.yml` which affected every job. For jobs that legitimately fail (e.g. Test, MSRV, Security), losing the cache after one transient failure slows down subsequent runs. Per-job parameterization keeps the cache-poisoning protection where it matters and the safe default elsewhere.

## Validation

- `yamllint` green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` green