### PR TITLE
fix(template): keep CHANGELOG.md at init, move entries to template

### DIFF
--- a/.template/CHANGELOG-TEMPLATE.md
+++ b/.template/CHANGELOG-TEMPLATE.md
@@ -13,7 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- for changes in existing functionality.
+- `setup-rust` composite action now exposes a `cache-on-failure` input
+  (default `true`); the Clippy job in CI overrides it to `false` so a
+  failed run cannot re-upload poisoned `.fingerprint/` metadata to the
+  rust-cache. Other jobs (Format, Test, Security, deny, Benchmarks, MSRV,
+  Version-check) keep the safe `true` default.
+- `examples/roast-scorer.rs` uses `Result<(), Box<dyn std::error::Error>>`-
+  returning `main` with `?`-propagation (no `.expect()` calls) and
+  `#![allow(missing_docs)]` so the example compiles under
+  `cargo clippy --all-targets -- -D warnings` (which enforces
+  `clippy::expect_used` and `missing_docs`). Behaviour for callers
+  invoking `cargo run --example roast-scorer` is unchanged.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,17 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `setup-rust` composite action now exposes a `cache-on-failure` input
-  (default `true`); the Clippy job in CI overrides it to `false` so a
-  failed run cannot re-upload poisoned `.fingerprint/` metadata to the
-  rust-cache. Other jobs (Format, Test, Security, deny, Benchmarks, MSRV,
-  Version-check) keep the safe `true` default.
-- `examples/roast-scorer.rs` now uses `Result<(), Box<dyn std::error::Error>>`-
-  returning `main` with `?`-propagation (no `.expect()` calls) and
-  `#![allow(missing_docs)]`, replacing the pre-merge version on
-  `origin/main` that violated `clippy::expect_used` and `missing_docs`
-  under `-D warnings`. Behaviour for callers invoking
-  `cargo run --example roast-scorer` is unchanged.
+- for changes in existing functionality.
 
 ### Deprecated
 


### PR DESCRIPTION
## Summary

This is a **template** repository, so per-instance files (`CHANGELOG.md`, `VERSION`) must remain at their init value. The cache-on-failure parameterization and roast-scorer swap entries that PRs #221 and #222 added to `CHANGELOG.md` belong in `.template/CHANGELOG-TEMPLATE.md` under `[Unreleased]`, so derived repos pick them up via `init-template.sh`.

## Changes

- `CHANGELOG.md`: reverted the two `[Unreleased] → Changed` bullets back to the single placeholder `- for changes in existing functionality.` (init value).
- `.template/CHANGELOG-TEMPLATE.md`: added the two entries under its `[Unreleased] → Changed` section, rephrased to be forward-looking (no `origin/main` references).
- `VERSION`: unchanged, stays at `0.0.0` (init value).

## Validation

- `yamllint` green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` green
- No other per-instance init files changed