### PR TITLE
docs(readme): add version and CI status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Rust 2026 Template
 
+[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](.template/CHANGELOG-TEMPLATE.md)
+[![CI](https://github.com/d-oit/rust-2026-template/actions/workflows/ci.yml/badge.svg)](https://github.com/d-oit/rust-2026-template/actions/workflows/ci.yml)
+
 <!-- cargo-sync-readme start -->
 
 A production-ready Rust workspace template with modern tooling, CI/CD and AI agent integration.


### PR DESCRIPTION
## Summary

Add two shields.io-style badges to the top of `README.md`:

- **Version**: `0.3.2` (sourced from `.template/CHANGELOG-TEMPLATE.md` version history) — links to the changelog file.
- **CI**: GitHub Actions status for the `ci.yml` workflow — links to the workflow run page.

## Placement

Badges are placed between the `# Rust 2026 Template` title and the `<!-- cargo-sync-readme start -->` marker, so they live in the hand-maintained section (not the cargo-sync-readme auto-synced block).

## Template-templating contract

The CI badge URL contains the exact substring `https://github.com/d-oit/rust-2026-template` that `init-template.sh` already rewrites to `$REPO_URL` for derived repos. The version badge intentionally shows the template's current changelog version (0.3.2), per user request.

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` green
- `markdownlint-cli2 README.md` clean
- `bash scripts/propagate-version.sh --check` passes
- Both badge URLs return HTTP 200
