### PR TITLE
docs(readme): add codecov, license, MSRV badges + templatize version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](.template/CHANGELOG-TEMPLATE.md)
 [![CI](https://github.com/d-oit/rust-2026-template/actions/workflows/ci.yml/badge.svg)](https://github.com/d-oit/rust-2026-template/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/d-oit/rust-2026-template/graph/badge.svg)](https://codecov.io/gh/d-oit/rust-2026-template)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://www.rust-lang.org)
 
 <!-- cargo-sync-readme start -->
 

--- a/scripts/init-template.sh
+++ b/scripts/init-template.sh
@@ -171,8 +171,14 @@ replace_in_file "QWEN.md" 'rust-2026-template' "$PROJECT_NAME"
 
 # --- rewrite README.md ---
 log "Updating README.md"
+# Specific badge-URL rewrites must run BEFORE the generic `rust-2026-template`
+# substitution below, otherwise the generic replace would mangle the badge URLs.
+# The version-badge search pattern is version-flexible (matches any semver) so
+# the script stays correct when the template's own version is bumped.
 replace_in_file "README.md" '# Rust 2026 Template' "# $PROJECT_NAME"
+replace_in_file "README.md" 'version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue\.svg' "version-$(cat VERSION)-blue.svg"
 replace_in_file "README.md" 'https://github.com/d-oit/rust-2026-template' "$REPO_URL"
+replace_in_file "README.md" 'https://codecov.io/gh/d-oit/rust-2026-template' "https://codecov.io/gh/${REPO}"
 replace_in_file "README.md" 'rust-2026-template' "$PROJECT_NAME"
 
 # --- rewrite CONTRIBUTING.md ---


### PR DESCRIPTION
## Summary

Combines two followups into one change:

1. **Templated version badge** — `init-template.sh` now rewrites the README version badge to match `VERSION` after init. The search pattern is version-flexible (matches any semver) so the script stays correct when the template's own version is bumped.
2. **More badges in README.md** — added Codecov, License (MIT), and MSRV (1.88) badges alongside the existing Version + CI badges.

## Changes

### `README.md`
3 new badges added after the existing Version + CI badges:
- `[![codecov](https://codecov.io/gh/d-oit/rust-2026-template/graph/badge.svg)](https://codecov.io/gh/d-oit/rust-2026-template)`
- `[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)`
- `[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://www.rust-lang.org)`

### `scripts/init-template.sh`
Added 2 new `replace_in_file` calls for README.md badge URLs, placed BEFORE the existing generic `rust-2026-template` substitution so the generic replace doesn't mangle the badge URLs:

- Version badge: version-flexible regex `version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue\.svg` → `version-$(cat VERSION)-blue.svg`
- Codecov badge URL: `https://codecov.io/gh/d-oit/rust-2026-template` → `https://codecov.io/gh/${REPO}`

## Template-templating contract

- The CI badge URL already gets templatized by the existing `https://github.com/d-oit/rust-2026-template` → `$REPO_URL` rule.
- The new codecov-badgetemplatize line rewrites `d-oit/rust-2026-template` to `${REPO}` (the org/name the user provides at init).
- The MSRV and License badges are static (no repository-specific data needed) and stay as-is in derived repos.
- The version badge starts at `version-0.0.0-blue.svg` (matching `VERSION`'s init value) in derived repos.

## Validation

- `shellcheck -x scripts/init-template.sh` — only pre-existing SC2059 informational warnings (not introduced here)
- `sed` dry-run: the flexible regex correctly matches `version-0.3.2-blue.svg`, `version-0.10.0-blue.svg`, `version-1.2.3-blue.svg`, and does not match unrelated strings
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — green
- `markdownlint-cli2 README.md` — 0 errors
- `bash scripts/propagate-version.sh --check` — passes (VERSION unchanged at 0.0.0)
- `yamllint` on workflow files — no errors
- All 3 new badge return HTTP 200
