### PR TITLE
feat(template): add /bump-template-version command

### DIFF
--- a/.opencode/commands/bump-template-version.md
+++ b/.opencode/commands/bump-template-version.md
@@ -1,0 +1,71 @@
+# Command: bump-template-version
+
+## Description
+Bumps the **template** repository's own internal version — the version tracked
+in `.template/CHANGELOG-TEMPLATE.md`'s link footer and reflected in the
+`README.md` version badge. This is **distinct** from the per-repo version
+tracked in `VERSION` / `Cargo.toml` `[workspace.package].version`, which stays
+at `0.0.0` (the init value that derived repos inherit) and is bumped separately
+by `scripts/bump-version.sh` after a repo is initialized via `init-template.sh`.
+
+## When to use
+After merging a batch of template improvements (CI/workflow fixes, new
+badges, new scripts, skill additions) and you're ready to publish the next
+template version. Typical cadence: few times per month, not per-PR.
+
+## Execution Protocol
+1. **Pre-flight (required):**
+   - Ensure `.template/CHANGELOG-TEMPLATE.md` has a populated `## [Unreleased]`
+     section with the changes you want to publish.
+   - Confirm `VERSION` and `Cargo.toml` `[workspace.package].version` are
+     still at `0.0.0` (the script will refuse to touch them, but verify
+     anyway as a sanity check).
+2. **Dry run (always do this first):**
+   ```bash
+   bash scripts/bump-template-version.sh
+   ```
+   Default: auto-increments the PATCH component of the current version.
+   Prints exactly which files/lines would change without modifying anything.
+3. **Apply:**
+   ```bash
+   bash scripts/bump-template-version.sh --execute
+   ```
+   Optional flags:
+   - `--minor`, `--major` to bump a non-patch component.
+   - `--version=X.Y.Z` to set an explicit version (skips auto-increment).
+   - `--date=YYYY-MM-DD` to override today's date in the changelog.
+4. **Review and commit:**
+   - `git diff .template/CHANGELOG-TEMPLATE.md README.md`
+   - `git add .template/CHANGELOG-TEMPLATE.md README.md`
+   - `git commit -m 'chore(template): bump version to X.Y.Z'`
+5. **Tag and push:**
+   ```bash
+   git tag vX.Y.Z
+   git push origin main --tags
+   ```
+
+## Color-flexibility
+The version badge rewrite is regex-driven:
+`version-<DIGITS>.<DIGITS>.<DIGITS>-<ANYCOLOR>.svg` → `version-<NEXT>-blue.svg`.
+It tolerates `blue`, `informational`, `green`, etc. so a shields.io colour
+change in `README.md` won't break the script.
+
+## What it does NOT touch
+- `VERSION` (per-instance init value, must stay at `0.0.0`)
+- `Cargo.toml` `[workspace.package].version` (workspace baseline)
+- `CHANGELOG.md` (per-instance template skeleton, stays empty)
+- `rust-toolchain.toml` (toolchain channel, not crate version)
+- `deny.toml`, `target/`, `.git/`
+
+## Goal
+Automate semantic version promotion for the **template infrastructure** (the
+files other repos consume) without colliding with the per-repo versioning
+that derived repos do on their own.
+
+## Scope note: template-only
+`scripts/bump-template-version.sh` is **template-infrastructure only**: it
+bumps `.template/CHANGELOG-TEMPLATE.md` and `README.md` on the rust-2026-template
+repo itself. **`init-template.sh` does NOT install this script into derived
+repos** — derived repos use `scripts/bump-version.sh` for their own per-repo
+versioning (which lives in `VERSION` / `Cargo.toml [workspace.package].version` /
+their own `CHANGELOG.md`, not in the template's `.template/` directory).

--- a/scripts/bump-template-version.sh
+++ b/scripts/bump-template-version.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# scripts/bump-template-version.sh
+set -euo pipefail
+#
+# Canonical source: the link footer of `.template/CHANGELOG-TEMPLATE.md`
+# (e.g. `[0.3.2]: https://...compare/v0.3.1...v0.3.2`). Mirrors the structure
+# of the standard Keep-a-Changelog footer.
+#
+# What this script updates:
+#   1. `.template/CHANGELOG-TEMPLATE.md`
+#      - Promotes `## [Unreleased]` → `## [NEXT] - <DATE>`
+#      - Inserts a fresh `[Unreleased]` skeleton above the new entry
+#      - Updates the `[Unreleased]` diff link to start from the new version
+#      - Adds a new `[NEXT]` link comparing the previous version to the new one
+#   2. `README.md`
+#      - Rewrites the version badge from any semver to `<NEXT>-blue.svg`
+#        (color-flexible; also handles `informational`, `green`, etc.)
+#
+# Files intentionally NOT touched:
+#   - VERSION                   (per-instance init value, stays 0.0.0)
+#   - Cargo.toml workspace.package.version
+#                                (workspace baseline, stays 0.0.0 — derived
+#                                 repos get their own versioning via
+#                                 scripts/bump-version.sh after init)
+#   - CHANGELOG.md              (per-instance template-skeleton, stays empty)
+#   - rust-toolchain.toml       (toolchain channel, not crate version)
+#   - deny.toml                 (supply-chain policy)
+#
+# Usage:
+#   ./scripts/bump-template-version.sh            # dry-run; bumps PATCH
+#   ./scripts/bump-template-version.sh --execute  # apply PATCH bump
+#   ./scripts/bump-template-version.sh --execute --minor
+#   ./scripts/bump-template-version.sh --execute --version=1.2.3
+#   ./scripts/bump-template-version.sh --execute --version=2.0.0 --date=2026-07-15
+#
+# Exit codes:
+#   0  success (dry-run or --execute completed)
+#   1  error (missing files, parse failure, etc.)
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+info()  { echo -e "${CYAN}[bump-template]${NC} $*"; }
+ok()    { echo -e "${GREEN}[bump-template]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[bump-template]${NC} $*"; }
+die()   { echo -e "${RED}[bump-template] ERROR:${NC} $*" >&2; exit 1; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+EXECUTE=false
+BUMP_TYPE="patch"
+FORCED_VERSION=""
+DATE_OVERRIDE="$(date -u +%Y-%m-%d)"
+
+print_help() {
+  sed -n '2,/^# Usage/p' "$0" | grep '^#' | sed 's/^# \?//'
+  exit 0
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --execute)               EXECUTE=true ;;
+    --major)                 BUMP_TYPE="major" ;;
+    --minor)                 BUMP_TYPE="minor" ;;
+    --patch)                 BUMP_TYPE="patch" ;;
+    --version=*)             FORCED_VERSION="${arg#*=}" ;;
+    --date=*)                DATE_OVERRIDE="${arg#*=}" ;;
+    --help|-h)               print_help ;;
+    *)                       die "Unknown argument: $arg. Use --help." ;;
+  esac
+done
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+CHANGELOG="$ROOT/.template/CHANGELOG-TEMPLATE.md"
+README="$ROOT/README.md"
+[[ -f "$CHANGELOG" ]] || die "Changelog not found at $CHANGELOG"
+
+# ── Helper: sed in-place (portable GNU + BSD/macOS) ───────────────────────────
+sedi() {
+  # $1 = sed expression, $2 = file
+  if sed --version 2>/dev/null | grep -q GNU; then
+    sed -i "$1" "$2"
+  else
+    sed -i '' "$1" "$2"
+  fi
+}
+
+# ── Read current template version from the changelog link footer ────────────
+# Header is `[Unreleased]:`. The remaining lines are `[X.Y.Z]:` entries. Filter
+# the versioned entries, then pick the semver-maximum (robust to footer being
+# in either descending or ascending order).
+CURRENT_VERSION=$(grep -oE '^\[[0-9]+\.[0-9]+\.[0-9]+\]: ' "$CHANGELOG" \
+  | sed -E 's/^\[([^]]+)\].*/\1/' \
+  | sort -V \
+  | tail -n 1)
+[[ -n "$CURRENT_VERSION" ]] || die "Could not parse current version from $CHANGELOG footer"
+
+# ── Compute the next version ─────────────────────────────────────────────────
+if [[ -n "$FORCED_VERSION" ]]; then
+  if ! [[ "$FORCED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    die "--version must match semver (X.Y.Z); got '$FORCED_VERSION'"
+  fi
+  NEXT_VERSION="$FORCED_VERSION"
+else
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+  [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]] \
+    || die "Current version '$CURRENT_VERSION' is not valid semver"
+  case "$BUMP_TYPE" in
+    major) NEXT_VERSION="$((MAJOR + 1)).0.0" ;;
+    minor) NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0" ;;
+    patch) NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+    *)     die "Invalid bump type: $BUMP_TYPE" ;;
+  esac
+fi
+
+info "Template version: $CURRENT_VERSION → $NEXT_VERSION (${DATE_OVERRIDE})"
+$EXECUTE || warn "DRY-RUN mode — pass --execute to apply changes"
+echo ""
+
+# ── Pre-flight checks ────────────────────────────────────────────────────────
+grep -q "^## \[Unreleased\]" "$CHANGELOG" \
+  || die "No '## [Unreleased]' section in $CHANGELOG — cannot promote"
+
+if grep -qF "[${NEXT_VERSION}]:" "$CHANGELOG"; then
+  die "Link footer already contains [${NEXT_VERSION}]: — refusing to duplicate"
+fi
+
+# ── 1. Update `.template/CHANGELOG-TEMPLATE.md` ─────────────────────────────
+if $EXECUTE; then
+  # a) Rename ## [Unreleased] → ## [NEXT] - DATE
+  sedi "s/^## \\[Unreleased\\]/## [${NEXT_VERSION}] - ${DATE_OVERRIDE}/" "$CHANGELOG"
+
+  # b) Insert a fresh [Unreleased] skeleton above the new versioned entry.
+  #    Using `printf` instead of literal `\n` escapes — GNU sed interprets
+  #    `\n` in inserted text as newlines, but BSD sed (macOS) treats them
+  #    literally, which would render the block on a single line. `printf`
+  #    expands `\n` at the shell level so both sed variants see real newlines.
+  UNRELEASED_BLOCK=$(printf '## [Unreleased]\n\n### Added\n\n### Changed\n\n### Deprecated\n\n### Removed\n\n### Fixed\n\n### Security\n\n---\n')
+  sedi "/^## \\[${NEXT_VERSION}\\]/i\\\\
+${UNRELEASED_BLOCK}" "$CHANGELOG"
+
+  # c) Update the [Unreleased] diff link (compare starts at the new version)
+  sedi "s|compare/v${CURRENT_VERSION}\\.\\.\\.HEAD|compare/v${NEXT_VERSION}...HEAD|g" "$CHANGELOG"
+
+  # d) Add the [NEXT_VERSION] link directly below the [Unreleased] link
+  NEW_LINK="[${NEXT_VERSION}]: https://github.com/d-oit/rust-2026-template/compare/v${CURRENT_VERSION}...v${NEXT_VERSION}"
+  sedi "/^\\[Unreleased\\]:/a\\\\
+${NEW_LINK}\\" "$CHANGELOG"
+
+  ok "Updated $CHANGELOG ([Unreleased] promoted to [$NEXT_VERSION] - $DATE_OVERRIDE)"
+else
+  warn "Would update $CHANGELOG (promote [Unreleased] → [$NEXT_VERSION] - $DATE_OVERRIDE)"
+fi
+
+# ── 2. Update `README.md` version badge ──────────────────────────────────────
+# Color-flexible: matches version-<SEMVER>-<ANYCOLOR>.svg and rewrites to
+# version-<NEXT>-blue.svg. Works for blue, informational, green, yellow, etc.
+if [[ -f "$README" ]]; then
+  BADGE_PATTERN='version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[a-zA-Z][a-zA-Z]*\.svg'
+  BADGE_REPLACE="version-${NEXT_VERSION}-blue.svg"
+
+  if grep -qE "$BADGE_PATTERN" "$README"; then
+    if $EXECUTE; then
+      sedi "s|${BADGE_PATTERN}|${BADGE_REPLACE}|g" "$README"
+      ok "Updated $README (version badge: ${CURRENT_VERSION} → ${NEXT_VERSION})"
+    else
+      warn "Would update $README (version badge: ${CURRENT_VERSION} → ${NEXT_VERSION})"
+    fi
+  else
+    warn "No version badge found in $README (pattern: ${BADGE_PATTERN}) — skipping"
+  fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+if $EXECUTE; then
+  ok "Template version bumped: $CURRENT_VERSION → $NEXT_VERSION"
+  info "Next steps:"
+  echo "  1. Review changes: git diff .template/CHANGELOG-TEMPLATE.md README.md"
+  echo "  2. Validate:       bash scripts/quality-gates.sh"
+  echo "  3. Commit:         git add .template/CHANGELOG-TEMPLATE.md README.md && \\"
+  echo "                       git commit -m 'chore(template): bump version to $NEXT_VERSION'"
+  echo "  4. Tag:            git tag v${NEXT_VERSION} && git push origin main --tags"
+else
+  info "Dry-run complete. Re-run with --execute to apply."
+fi


### PR DESCRIPTION
## Summary

Adds `/bump-template-version` — a new custom command and script that bumps the **template repository's own internal version** (tracked in `.template/CHANGELOG-TEMPLATE.md` and reflected in the `README.md` version badge). This is **distinct** from the per-repo version tracked in `VERSION` / `Cargo.toml [workspace.package].version` (which stays at `0.0.0` for the template itself and is bumped separately for each derived repo via the existing `scripts/bump-version.sh` after `init-template.sh` runs).

## Changes

### `scripts/bump-template-version.sh` (new, ~210 lines, executable)
- Reads the current template version from `.template/CHANGELOG-TEMPLATE.md` link footer using `sort -V | tail -n1` (robust to footer being in either ascending or descending order).
- Computes the next version: auto-increments PATCH by default; supports `--major`, `--minor`, `--version=X.Y.Z`, `--date=YYYY-MM-DD`.
- Touches ONLY `.template/CHANGELOG-TEMPLATE.md` (promotes `[Unreleased]` → `[NEXT] - DATE`, inserts fresh `[Unreleased]` skeleton, updates `[Unreleased]` diff link, adds `[NEXT]` link) and `README.md` (color-flexible badge rewrite).
- Refuses to touch `VERSION`, `Cargo.toml [workspace.package].version`, `CHANGELOG.md`, `rust-toolchain.toml`, `deny.toml` (per-instance init values are preserved).
- Uses portable GNU/BSD `sedi()` helper copied from `scripts/bump-version.sh`.
- Uses `printf`-built insertion blocks (instead of literal `\n` escapes) so BSD sed (macOS) renders the block correctly.
- Defaults to dry-run; `--execute` applies.

### `.opencode/commands/bump-template-version.md` (new)
New custom command doc following the existing `generate-docs.md` / `resume.md` format with sections: Description, When to use, Execution Protocol (5 steps), Color-flexibility, What it does NOT touch, Scope note (template-only), Goal.

## Usage

```bash
bash scripts/bump-template-version.sh                        # dry-run, PATCH bump
bash scripts/bump-template-version.sh --execute              # apply PATCH bump
bash scripts/bump-template-version.sh --execute --minor     # MINOR bump
bash scripts/bump-template-version.sh --execute --version=1.0.0
bash scripts/bump-template-version.sh --help
```

## Validation

- `shellcheck scripts/bump-template-version.sh` — 0 issues
- Dry-runs: all three modes (default, `--minor`, `--version=1.0.0`) compute correctly (0.3.2 → 0.3.3, 0.3.2 → 0.4.0, 0.3.2 → 1.0.0)
- Footer-order robustness: `sort -V | tail -n1` correctly picks semver-maximum for both ascending and descending footers
- `printf` newlines verified via `od -c` (real `\n` bytes, not literal escapes)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — green
- `bash scripts/propagate-version.sh --check` — passes (per-instance VERSION = 0.0.0 unchanged)
- No regressions: VERSION, Cargo.toml workspace.package.version, CHANGELOG.md all stay at their init values.

## Color-flexibility

Both `init-template.sh` (previously merged in PR #225) and the new `bump-template-version.sh` use the same regex pattern:

```
version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[a-zA-Z][a-zA-Z]*\.svg
```

which matches `version-X.Y.Z-<any-color>.svg` and rewrites to `version-NEXT-blue.svg`. Tolerates `blue`, `informational`, `green`, `yellow`, etc.
