### PR TITLE
refactor(template): make changelog-template the sole source of the template version

### DIFF
--- a/.opencode/commands/bump-template-version.md
+++ b/.opencode/commands/bump-template-version.md
@@ -2,11 +2,16 @@
 
 ## Description
 Bumps the **template** repository's own internal version — the version tracked
-in `.template/CHANGELOG-TEMPLATE.md`'s link footer and reflected in the
-`README.md` version badge. This is **distinct** from the per-repo version
-tracked in `VERSION` / `Cargo.toml` `[workspace.package].version`, which stays
-at `0.0.0` (the init value that derived repos inherit) and is bumped separately
-by `scripts/bump-version.sh` after a repo is initialized via `init-template.sh`.
+in `.template/CHANGELOG-TEMPLATE.md`'s link footer. **This is the SOLE place
+where the template's version lives**, by design — `VERSION`, `CHANGELOG.md`,
+`Cargo.toml [workspace.package].version`, and the `README.md` version badge are
+all kept free of any version number so a `bump-template-version` run mutates
+exactly one file.
+
+The per-repo version that derived repos use (in their own `VERSION` /
+`Cargo.toml [workspace.package].version` / `CHANGELOG.md`) starts at `0.0.0`
+(the init value they inherit) and is bumped separately by
+`scripts/bump-version.sh` after a repo is initialized via `init-template.sh`.
 
 ## When to use
 After merging a batch of template improvements (CI/workflow fixes, new
@@ -17,15 +22,18 @@ template version. Typical cadence: few times per month, not per-PR.
 1. **Pre-flight (required):**
    - Ensure `.template/CHANGELOG-TEMPLATE.md` has a populated `## [Unreleased]`
      section with the changes you want to publish.
-   - Confirm `VERSION` and `Cargo.toml` `[workspace.package].version` are
-     still at `0.0.0` (the script will refuse to touch them, but verify
-     anyway as a sanity check).
+   - Confirm `VERSION`, `CHANGELOG.md`, and `Cargo.toml [workspace.package].version`
+     are still in their initial (untouched) state (`VERSION` = `0.0.0`, the
+     generated-project starter version; `CHANGELOG.md` = empty Keep-a-Changelog
+     skeleton). The script will refuse to touch them, but verify as a sanity
+     check.
 2. **Dry run (always do this first):**
    ```bash
    bash scripts/bump-template-version.sh
    ```
    Default: auto-increments the PATCH component of the current version.
-   Prints exactly which files/lines would change without modifying anything.
+   Prints exactly which lines in `.template/CHANGELOG-TEMPLATE.md` would
+   change without modifying anything.
 3. **Apply:**
    ```bash
    bash scripts/bump-template-version.sh --execute
@@ -35,8 +43,8 @@ template version. Typical cadence: few times per month, not per-PR.
    - `--version=X.Y.Z` to set an explicit version (skips auto-increment).
    - `--date=YYYY-MM-DD` to override today's date in the changelog.
 4. **Review and commit:**
-   - `git diff .template/CHANGELOG-TEMPLATE.md README.md`
-   - `git add .template/CHANGELOG-TEMPLATE.md README.md`
+   - `git diff .template/CHANGELOG-TEMPLATE.md` (should be exactly ONE file)
+   - `git add .template/CHANGELOG-TEMPLATE.md`
    - `git commit -m 'chore(template): bump version to X.Y.Z'`
 5. **Tag and push:**
    ```bash
@@ -44,28 +52,24 @@ template version. Typical cadence: few times per month, not per-PR.
    git push origin main --tags
    ```
 
-## Color-flexibility
-The version badge rewrite is regex-driven:
-`version-<DIGITS>.<DIGITS>.<DIGITS>-<ANYCOLOR>.svg` → `version-<NEXT>-blue.svg`.
-It tolerates `blue`, `informational`, `green`, etc. so a shields.io colour
-change in `README.md` won't break the script.
-
-## What it does NOT touch
-- `VERSION` (per-instance init value, must stay at `0.0.0`)
-- `Cargo.toml` `[workspace.package].version` (workspace baseline)
-- `CHANGELOG.md` (per-instance template skeleton, stays empty)
+## What it does NOT touch (intentionally single-file)
+- `.template/CHANGELOG-TEMPLATE.md` is the **only** file mutated.
+- `VERSION` (kept at `0.0.0` — this is the generated-project starter version, not the template's own)
+- `CHANGELOG.md` (kept in its initial Keep-a-Changelog skeleton state — this is the generated-project changelog, not the template's own)
+- `Cargo.toml` `[workspace.package].version` (workspace baseline; stays `0.0.0` — derived repos inherit and bump locally via `scripts/bump-version.sh`)
+- `README.md` (no version badge — the changelog IS the source of truth)
 - `rust-toolchain.toml` (toolchain channel, not crate version)
 - `deny.toml`, `target/`, `.git/`
 
 ## Goal
-Automate semantic version promotion for the **template infrastructure** (the
-files other repos consume) without colliding with the per-repo versioning
-that derived repos do on their own.
+Keep the **template's own version** atomic to a single file so the diff for
+any `bump-template-version` run is trivially reviewable and reviewable in
+isolation from per-repo version changes.
 
 ## Scope note: template-only
 `scripts/bump-template-version.sh` is **template-infrastructure only**: it
-bumps `.template/CHANGELOG-TEMPLATE.md` and `README.md` on the rust-2026-template
-repo itself. **`init-template.sh` does NOT install this script into derived
+bumps `.template/CHANGELOG-TEMPLATE.md` on the rust-2026-template repo
+itself. **`init-template.sh` does NOT install this script into derived
 repos** — derived repos use `scripts/bump-version.sh` for their own per-repo
 versioning (which lives in `VERSION` / `Cargo.toml [workspace.package].version` /
 their own `CHANGELOG.md`, not in the template's `.template/` directory).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Rust 2026 Template
 
-[![Version](https://img.shields.io/badge/version-0.3.2-blue.svg)](.template/CHANGELOG-TEMPLATE.md)
 [![CI](https://github.com/d-oit/rust-2026-template/actions/workflows/ci.yml/badge.svg)](https://github.com/d-oit/rust-2026-template/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/d-oit/rust-2026-template/graph/badge.svg)](https://codecov.io/gh/d-oit/rust-2026-template)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://www.rust-lang.org)
+
+**Latest release:** see [`.template/CHANGELOG-TEMPLATE.md`](.template/CHANGELOG-TEMPLATE.md) — the changelog is the single source of truth for the template's version history.
 
 <!-- cargo-sync-readme start -->
 

--- a/scripts/bump-template-version.sh
+++ b/scripts/bump-template-version.sh
@@ -6,23 +6,28 @@ set -euo pipefail
 # (e.g. `[0.3.2]: https://...compare/v0.3.1...v0.3.2`). Mirrors the structure
 # of the standard Keep-a-Changelog footer.
 #
-# What this script updates:
-#   1. `.template/CHANGELOG-TEMPLATE.md`
-#      - Promotes `## [Unreleased]` → `## [NEXT] - <DATE>`
-#      - Inserts a fresh `[Unreleased]` skeleton above the new entry
-#      - Updates the `[Unreleased]` diff link to start from the new version
-#      - Adds a new `[NEXT]` link comparing the previous version to the new one
-#   2. `README.md`
-#      - Rewrites the version badge from any semver to `<NEXT>-blue.svg`
-#        (color-flexible; also handles `informational`, `green`, etc.)
+# Design principle: `.template/CHANGELOG-TEMPLATE.md` is the SOLE source of
+# truth for the template's own version. All other files that could otherwise
+# carry a version are intentionally NOT touched, so a `bump-template-version`
+# run mutates exactly one file and produces a clean atomic diff.
 #
-# Files intentionally NOT touched:
-#   - VERSION                   (per-instance init value, stays 0.0.0)
+# What this script updates:
+#   - `.template/CHANGELOG-TEMPLATE.md`:
+#       - Promotes `## [Unreleased]` → `## [NEXT] - <DATE>`
+#       - Inserts a fresh `[Unreleased]` skeleton above the new entry
+#       - Updates the `[Unreleased]` diff link to start from the new version
+#       - Adds a new `[NEXT]` link comparing the previous version to the new one
+#
+# Files intentionally NOT touched (this is the whole point):
+#   - VERSION                   (per-template init value; intentionally stays 0.0.0)
+#   - CHANGELOG.md              (per-template generated-project changelog; intentionally
+#                                stays in its initial skeleton state — derived repos
+#                                own this file via scripts/bump-version.sh)
 #   - Cargo.toml workspace.package.version
-#                                (workspace baseline, stays 0.0.0 — derived
-#                                 repos get their own versioning via
-#                                 scripts/bump-version.sh after init)
-#   - CHANGELOG.md              (per-instance template-skeleton, stays empty)
+#                                (workspace baseline; intentionally stays 0.0.0 —
+#                                 derived repos inherit and bump separately)
+#   - README.md                 (no version badge — the changelog-template IS the
+#                                single source of truth for the template's version)
 #   - rust-toolchain.toml       (toolchain channel, not crate version)
 #   - deny.toml                 (supply-chain policy)
 #
@@ -74,7 +79,6 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT"
 
 CHANGELOG="$ROOT/.template/CHANGELOG-TEMPLATE.md"
-README="$ROOT/README.md"
 [[ -f "$CHANGELOG" ]] || die "Changelog not found at $CHANGELOG"
 
 # ── Helper: sed in-place (portable GNU + BSD/macOS) ───────────────────────────
@@ -154,33 +158,14 @@ else
   warn "Would update $CHANGELOG (promote [Unreleased] → [$NEXT_VERSION] - $DATE_OVERRIDE)"
 fi
 
-# ── 2. Update `README.md` version badge ──────────────────────────────────────
-# Color-flexible: matches version-<SEMVER>-<ANYCOLOR>.svg and rewrites to
-# version-<NEXT>-blue.svg. Works for blue, informational, green, yellow, etc.
-if [[ -f "$README" ]]; then
-  BADGE_PATTERN='version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-[a-zA-Z][a-zA-Z]*\.svg'
-  BADGE_REPLACE="version-${NEXT_VERSION}-blue.svg"
-
-  if grep -qE "$BADGE_PATTERN" "$README"; then
-    if $EXECUTE; then
-      sedi "s|${BADGE_PATTERN}|${BADGE_REPLACE}|g" "$README"
-      ok "Updated $README (version badge: ${CURRENT_VERSION} → ${NEXT_VERSION})"
-    else
-      warn "Would update $README (version badge: ${CURRENT_VERSION} → ${NEXT_VERSION})"
-    fi
-  else
-    warn "No version badge found in $README (pattern: ${BADGE_PATTERN}) — skipping"
-  fi
-fi
-
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 if $EXECUTE; then
   ok "Template version bumped: $CURRENT_VERSION → $NEXT_VERSION"
   info "Next steps:"
-  echo "  1. Review changes: git diff .template/CHANGELOG-TEMPLATE.md README.md"
+  echo "  1. Review changes: git diff .template/CHANGELOG-TEMPLATE.md"
   echo "  2. Validate:       bash scripts/quality-gates.sh"
-  echo "  3. Commit:         git add .template/CHANGELOG-TEMPLATE.md README.md && \\"
+  echo "  3. Commit:         git add .template/CHANGELOG-TEMPLATE.md && \\"
   echo "                       git commit -m 'chore(template): bump version to $NEXT_VERSION'"
   echo "  4. Tag:            git tag v${NEXT_VERSION} && git push origin main --tags"
 else

--- a/scripts/init-template.sh
+++ b/scripts/init-template.sh
@@ -173,10 +173,10 @@ replace_in_file "QWEN.md" 'rust-2026-template' "$PROJECT_NAME"
 log "Updating README.md"
 # Specific badge-URL rewrites must run BEFORE the generic `rust-2026-template`
 # substitution below, otherwise the generic replace would mangle the badge URLs.
-# The version-badge search pattern is version-flexible (matches any semver) so
-# the script stays correct when the template's own version is bumped.
+# NOTE: no version-badge rewrite here by design — the template's README no longer
+# carries a version badge; the template's version is tracked exclusively in
+# `.template/CHANGELOG-TEMPLATE.md` (see scripts/bump-template-version.sh).
 replace_in_file "README.md" '# Rust 2026 Template' "# $PROJECT_NAME"
-replace_in_file "README.md" 'version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue\.svg' "version-$(cat VERSION)-blue.svg"
 replace_in_file "README.md" 'https://github.com/d-oit/rust-2026-template' "$REPO_URL"
 replace_in_file "README.md" 'https://codecov.io/gh/d-oit/rust-2026-template' "https://codecov.io/gh/${REPO}"
 replace_in_file "README.md" 'rust-2026-template' "$PROJECT_NAME"


### PR DESCRIPTION

---
## Summary

Make `.template/CHANGELOG-TEMPLATE.md` the **sole** file that tracks the rust-2026-template own version. The previous iteration updated `README.md` alongside it; this one removes that redundant update so every `bump-template-version` run produces a clean single-file diff.

## Why

`Versioning principle: VERSION = 0.0.0 (locked init value), CHANGELOG.md = initial skeleton (locked), only the changelog-template reflects the template evolution. README had a version badge that would go stale every release — removed.`

## Changes

| File | Change |
|------|--------|
| `scripts/bump-template-version.sh` | Drop README update block, drop dead `$README` variable, rewrite header to declare single-file invariant |
| `scripts/init-template.sh` | Drop the version-flexible README badge regex (no longer needed) |
| `README.md` | Remove the `[![Version](...)]` line; add a prose pointer to the changelog |
| `.opencode/commands/bump-template-version.md` | Rewrite to reflect single-file scope; remove the Color-flexibility section |

## Validation

- `shellcheck scripts/bump-template-version.sh`: 0 warnings, exit 0
- `bash scripts/bump-template-version.sh` (dry-run): ONLY `.template/CHANGELOG-TEMPLATE.md` is reported as "Would update"
- `bash scripts/bump-template-version.sh --minor` / `--version=9.9.9`: correct math
- `--version=abc`: correctly rejected
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `bash scripts/propagate-version.sh --check`: passes (`VERSION=0.0.0`)
- All surviving badge URLs (CI, Codecov, License, MSRV) return HTTP 200

## Test plan

1. CI gating jobs (Conventional Commits, Detect Changes, Codacy, Auto-Label) should all stay green since the diff touches only docs + scripts and removes a code path.
2. After merge: `grep -r version-0\.3\.2 --exclude-dir=target --exclude-dir=.git --exclude-dir=.agents` should only return matches inside `.template/CHANGELOG-TEMPLATE.md` (history entries).

/cc @d-oit
