### PR TITLE
Document platform-specific fast-build options

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,9 +5,8 @@
 # mold is the fastest available linker on Linux, ~7x faster than default ld.
 # Requires: apt install mold clang  (Ubuntu/Debian)  or  brew install mold (Linuxbrew)
 # If mold is not installed, Rust 1.90+ falls back to rust-lld automatically.
-[target.x86_64-unknown-linux-gnu]
-
-[target.aarch64-unknown-linux-gnu]
+# [target.x86_64-unknown-linux-gnu]
+# [target.aarch64-unknown-linux-gnu]
 
 # ─── macOS: default linker ──────────────────────────────────────────────────
 # macOS's default ld64 is already fast, especially on Apple Silicon.
@@ -21,24 +20,22 @@
 # ─── Windows MSVC: rust-lld ─────────────────────────────────────────────────
 # rust-lld ships with the Rust toolchain — no extra install needed.
 # Benchmarks show 2-5x faster linking vs default MSVC link.exe.
-[target.x86_64-pc-windows-msvc]
-linker = "rust-lld"
+# [target.x86_64-pc-windows-msvc]
+# linker = "rust-lld"
 
-[target.aarch64-pc-windows-msvc]
-linker = "rust-lld"
+# [target.aarch64-pc-windows-msvc]
+# linker = "rust-lld"
 
 # ─── Windows GNU (MinGW): rust-lld ──────────────────────────────────────────
-[target.x86_64-pc-windows-gnu]
-linker = "rust-lld"
+# [target.x86_64-pc-windows-gnu]
+# linker = "rust-lld"
 
-[target.aarch64-pc-windows-gnu]
-linker = "rust-lld"
+# [target.aarch64-pc-windows-gnu]
+# linker = "rust-lld"
 
 # ─── WSL2 note ──────────────────────────────────────────────────────────────
-# WSL2 uses the Linux x86_64 target, so it benefits from mold automatically.
-# If mold/clang are not installed in your WSL2 distro, either:
-#   1. sudo apt install mold clang
-#   2. Remove the linux target block above — Rust 1.90+ uses rust-lld by default
+# WSL2 uses the Linux x86_64 target. To use mold in WSL2, follow the Linux setup
+# instructions in docs/src/faster-builds.md.
 
 # ─── Dev profile disk space optimization ────────────────────────────────────
 # Reduces target/ from ~5GB to ~2GB in large workspaces.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,11 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [profile.dev]
 opt-level = 0
 
+# Fast development profile: prioritizes compilation speed over runtime performance.
+[profile.fast-dev]
+inherits = "dev"
+panic = "abort"
+
 # Optimised release: maximum runtime performance at the cost of build time.
 [profile.release]
 opt-level = 3

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -169,6 +169,7 @@ The fuzzer is also configured to run weekly via GitHub Actions.
 
 - Read `AGENTS.md` to understand how AI coding assistants are configured
 - Read `CONTRIBUTING.md` before making changes
+- Read [Faster Builds](docs/src/faster-builds.md) to optimize your development workflow
 - Check `MIGRATION.md` if adopting this template in an existing project
 - See `agents-docs/conventions.md` for coding conventions enforced by agents
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,3 +3,4 @@
 - [Overview](./README.md)
 - [Getting Started](./getting-started.md)
 - [Architecture](./architecture.md)
+- [Faster Builds](./faster-builds.md)

--- a/docs/src/faster-builds.md
+++ b/docs/src/faster-builds.md
@@ -1,0 +1,107 @@
+# Faster Builds
+
+This guide provides strategies to improve Rust compilation times. While the template includes sensible defaults, some highly effective optimizations are platform-specific or depend on your development workflow.
+
+## Universal Guidance
+
+### 1. Use `cargo check`
+For quick validation of your code, use `cargo check` instead of `cargo build`. It skips the code generation phase, which is often the most time-consuming part of the build process.
+
+### 2. Use the Opt-in `fast-dev` Profile
+The template includes a `fast-dev` profile optimized for compilation speed. It inherits from the standard `dev` profile but sets `panic = "abort"` to reduce the amount of work the compiler needs to do by removing the need for stack unwinding information.
+
+To use it:
+```bash
+cargo build --profile fast-dev
+```
+
+### 3. Identify Bottlenecks with `--timings`
+If you're wondering why your build is slow, use the `--timings` flag:
+```bash
+cargo build --timings
+```
+This generates an HTML report in `target/cargo-timings/` showing which crates took the longest to compile and how much parallelism was achieved.
+
+---
+
+## Platform-Specific Optimizations
+
+These optimizations are not enabled by default as they require external tools or specific OS configurations.
+
+### Linux: `mold` Linker
+The `mold` linker is significantly faster than the default `ld` or `gold` linkers.
+
+**Setup:**
+1. Install `mold` (e.g., `sudo apt install mold`).
+2. Add the following to your `.cargo/config.toml`:
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+```
+
+### macOS: Split Debug Info
+On macOS, the linker (`ld64`) can spend a lot of time packaging debug information into `.dSYM` bundles. You can skip this by using "unpacked" debug info.
+
+Add the following to your `.cargo/config.toml`:
+
+```toml
+[target.aarch64-apple-darwin]
+split-debuginfo = "unpacked"
+
+[target.x86_64-apple-darwin]
+split-debuginfo = "unpacked"
+```
+
+### Windows: Dev Drive
+If you are on Windows 11, using a **Dev Drive** (ReFS) can significantly improve I/O performance for Rust builds.
+
+1. Create a Dev Drive in Windows Settings.
+2. Move your project or your `CARGO_HOME` to the Dev Drive.
+3. Ensure your antivirus (e.g., Microsoft Defender) is in "performance mode" for the Dev Drive.
+
+---
+
+## Recommended Configuration (Opt-in)
+
+If you have the prerequisites installed for your platform, we recommend adding these blocks to your local or project-level configuration.
+
+### For `.cargo/config.toml`
+
+```toml
+# Linux (requires mold and clang)
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+# macOS (split-debuginfo = "unpacked")
+[target.aarch64-apple-darwin]
+split-debuginfo = "unpacked"
+
+[target.x86_64-apple-darwin]
+split-debuginfo = "unpacked"
+
+# Windows (if you prefer rust-lld)
+# [target.x86_64-pc-windows-msvc]
+# linker = "rust-lld"
+```
+
+### For `Cargo.toml`
+
+The `fast-dev` profile is already included in the workspace `Cargo.toml`. You can customize it further if needed:
+
+```toml
+[profile.fast-dev]
+inherits = "dev"
+panic = "abort"
+# Add more speed-oriented overrides here
+```

--- a/docs/src/faster-builds.md
+++ b/docs/src/faster-builds.md
@@ -11,15 +11,18 @@ For quick validation of your code, use `cargo check` instead of `cargo build`. I
 The template includes a `fast-dev` profile optimized for compilation speed. It inherits from the standard `dev` profile but sets `panic = "abort"` to reduce the amount of work the compiler needs to do by removing the need for stack unwinding information.
 
 To use it:
+
 ```bash
 cargo build --profile fast-dev
 ```
 
 ### 3. Identify Bottlenecks with `--timings`
 If you're wondering why your build is slow, use the `--timings` flag:
+
 ```bash
 cargo build --timings
 ```
+
 This generates an HTML report in `target/cargo-timings/` showing which crates took the longest to compile and how much parallelism was achieved.
 
 ---

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -1,3 +1,4 @@
+---
 # monitoring/docker-compose.monitoring.yml
 # Stub — extend with your actual Prometheus/Grafana config
 version: '3.8'

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,3 +1,4 @@
+---
 # monitoring/prometheus.yml
 global:
   scrape_interval: 15s

--- a/reports/roast-report.json
+++ b/reports/roast-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-07-06T14:00:48Z",
+  "timestamp": "2026-07-07T09:15:48Z",
   "total_score": 90,
   "pass_threshold": 80,
   "pass": true,

--- a/reports/roast-report.json
+++ b/reports/roast-report.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-07-07T09:15:48Z",
+  "timestamp": "2026-07-07T09:34:27Z",
   "total_score": 90,
   "pass_threshold": 80,
   "pass": true,


### PR DESCRIPTION
This PR introduces a comprehensive "Faster Builds" guide to help users optimize their Rust compilation times without hardcoding non-portable configurations into the template.

Key changes:
1. **New Documentation**: Added `docs/src/faster-builds.md` covering `cargo check`, `--timings`, the `fast-dev` profile, and platform-specific opts (mold for Linux, split-debuginfo for macOS, Dev Drive for Windows).
2. **Opt-in Profile**: Added `[profile.fast-dev]` to the workspace `Cargo.toml` with `panic = "abort"` for speed.
3. **Configuration Cleanup**: Commented out `linker = "rust-lld"` and other platform-specific linkers in `.cargo/config.toml` to comply with the "no platform-specific linker by default" requirement.
4. **Onboarding**: Linked the new guide from `QUICKSTART.md` and added it to the mdBook `SUMMARY.md`.

These changes ensure the template remains universally compatible while providing clear paths for developers to optimize their local environments.

Fixes #240

---
*PR created automatically by Jules for task [12844106516168200746](https://jules.google.com/task/12844106516168200746) started by @d-oit*