### PR TITLE
Disable incremental compilation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  # Disable incremental compilation in CI to reduce I/O overhead.
+  CARGO_INCREMENTAL: 0
   RUSTC_WRAPPER: sccache
   SCCACHE_GHA_ENABLED: "true"
 


### PR DESCRIPTION
Disabled incremental compilation in `.github/workflows/ci.yml` by setting `CARGO_INCREMENTAL: 0` in the top-level `env` section. This reduces I/O overhead for CI builds which are typically clean or near-clean. Added a descriptive comment to the workflow file as requested. Verified the change and ensured it adheres to project standards.

Fixes #238

---
*PR created automatically by Jules for task [6612805323126386174](https://jules.google.com/task/6612805323126386174) started by @d-oit*