### PR TITLE
feat(release): add [workspace.metadata.release] to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,18 @@ insta = { version = "1", features = ["yaml"] }
 colored = "3"
 criterion = { version = "0.5", features = ["html_reports"] }
 
+# ─── cargo-release configuration ─────────────────────────────────────────────────────
+# Instruct `cargo release` to version all workspace members together.
+# Run: cargo release --workspace patch   (or minor / major)
+# Docs: https://github.com/crate-ci/cargo-release/blob/master/docs/reference.md
+[workspace.metadata.release]
+shared-version = true
+consolidate-commits = true
+pre-release-commit-message = "chore: release v{{version}}"
+tag-message = "Release v{{version}}"
+tag-name = "v{{version}}"
+release = true
+
 # ─── Build profiles ───────────────────────────────────────────────────────────
 [profile.dev]
 opt-level = 0

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,11 @@ insta-review:  ## Review and approve insta snapshot changes
 ## monitoring-help: Show available monitoring targets
 monitoring-help:
 	@grep -E '^## ' Makefile.monitoring | sed 's/## /  /'
+
+## Cut a patch release (bumps all workspace members)
+release-patch:
+	cargo release --workspace patch
+
+## Cut a minor release
+release-minor:
+	cargo release --workspace minor

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -128,6 +128,19 @@ git push origin main
 
 CI runs: format check, clippy, nextest, doc tests, security audit, cargo-deny, MSRV check.
 
+## Cutting a Release
+
+1. Ensure your working tree is clean.
+2. Run: `cargo release --workspace patch` (or `minor` / `major`)
+   - This bumps all workspace member versions together.
+   - Tags the commit as `v<version>`.
+   - Pushes the tag, triggering the release CI workflow.
+3. The GitHub Actions release workflow will:
+   - Run `git-cliff` to update `CHANGELOG.md`
+   - Create a GitHub Release with the generated notes
+
+For a dry-run (no changes): `cargo release --workspace patch --dry-run`
+
 ---
 
 ## What You Get

--- a/release.toml
+++ b/release.toml
@@ -1,6 +1,8 @@
-# Configuration for cargo-release
+# release.toml — project-level overrides only.
+# Workspace-level defaults live in Cargo.toml [workspace.metadata.release].
 [workspace]
-consolidate-commits = true
+push = true
+publish = false   # set to true if publishing to crates.io
 consolidate-pushes = true
 pre-release-hook = ["./scripts/pre-release-hook.sh"]
 # Update changelog using git-cliff
@@ -16,7 +18,3 @@ pre-release-replacements = [
 # actually, better to handle it in pre-release-hook.sh
 # or use the [changelog] section if available in the version being used.
 # Let's add it to the pre-release-hook.sh for maximum flexibility.
-
-[[package]]
-name = "rust-2026-template"
-tag-name = "v{{version}}"


### PR DESCRIPTION
This PR adds the `[workspace.metadata.release]` block to `Cargo.toml` to ensure consistent versioning across all workspace members when using `cargo-release`. 

Key changes:
- Centralized `cargo-release` configuration in `Cargo.toml` with `shared-version = true`.
- Deduplicated `release.toml` and set project-level overrides for `push` and `publish`.
- Added a "Cutting a Release" section to `QUICKSTART.md`.
- Added `release-patch` and `release-minor` targets to the `Makefile`.

These changes improve the developer experience for adopters of the template by providing a clear and consistent release workflow.

Fixes #251

---
*PR created automatically by Jules for task [6558607743058426148](https://jules.google.com/task/6558607743058426148) started by @d-oit*