### PR TITLE
fix(init-template): resolve stale deps and duplicate package name (#260)

### DIFF
--- a/.github/workflows/test-init-template.yml
+++ b/.github/workflows/test-init-template.yml
@@ -1,0 +1,73 @@
+---
+# .github/workflows/test-init-template.yml
+# Verify init-template.sh produces a valid workspace on all OS.
+# Manual trigger only.
+name: Test init-template
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-init:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@188cf5c4b4e181f63a20b691e6b72e33b8eae1e6 # stable
+        with:
+          toolchain: "1.88"
+
+      - name: Run init-template.sh
+        shell: bash
+        run: |
+          cp -r . /tmp/init-test
+          cd /tmp/init-test
+          bash scripts/init-template.sh \
+            --name test-project \
+            --description "CI verification test" \
+            --author "CI Bot" \
+            --repo "test/test-project"
+
+      - name: Verify cargo check
+        shell: bash
+        run: |
+          cd /tmp/init-test
+          cargo check --workspace
+
+      - name: Verify no stale example-crate references
+        shell: bash
+        run: |
+          cd /tmp/init-test
+          if grep -r "example-crate" \
+            examples/hello_world/Cargo.toml \
+            benchmarks/Cargo.toml \
+            fuzz/Cargo.toml \
+            crates/test-project/; then
+            echo "ERROR: Stale example-crate references found"
+            exit 1
+          fi
+          echo "OK: No stale references"
+
+      - name: Verify crate name
+        shell: bash
+        run: |
+          cd /tmp/init-test
+          if ! grep -q 'name = "test-project"' crates/test-project/Cargo.toml; then
+            echo "ERROR: Crate name not updated"
+            exit 1
+          fi
+          echo "OK: Crate name correct"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -168,7 +168,9 @@ Key additions: `/target`, `*.swp`, `.direnv/`, `.envrc`.
 
 ## Crate Naming (Template Rename)
 
-When using this template, always rename `example-crate` before first publish:
+When using this template, always rename `example-crate` before first publish. If you used `init-template.sh`, the rename and all dependency path updates are handled automatically.
+
+For manual renames:
 
 1. Rename the directory: `mv crates/example-crate crates/your-crate-name`
 2. Update `crates/your-crate-name/Cargo.toml`: `name = "your-crate-name"`

--- a/scripts/init-template.sh
+++ b/scripts/init-template.sh
@@ -120,6 +120,21 @@ replace_in_file() {
   fi
 }
 
+# --- replace literal string in file (escapes [ ] for sed) ---
+replace_literal() {
+  local file="$1"
+  local literal="$2"
+  local replacement="$3"
+  if [[ $DRY_RUN -eq 1 ]]; then
+    ok "(dry run) Would update $file"
+  elif [[ -f "$file" ]]; then
+    local escaped
+    escaped=$(printf '%s' "$literal" | sed 's/[][]/\\&/g')
+    sedi "s|$escaped|$replacement|g" "$file"
+    ok "Updated $file"
+  fi
+}
+
 # --- remove path (dry-run aware) ---
 remove_path() {
   local path="$1"
@@ -199,7 +214,11 @@ fi
 
 # --- rewrite Cargo.toml (workspace) ---
 log "Updating Cargo.toml"
-replace_in_file "Cargo.toml" 'name = "rust-2026-template"' "name = \"$PROJECT_NAME\""
+# Strip root [package], [dependencies], [dev-dependencies], [lints] —
+# the workspace root must be a virtual manifest (no own crate).
+for section in package dependencies dev-dependencies lints; do
+  sedi "/^\[$section\]/,/^\[/{ /^\[$section\]/d; /^\[/!d; }" Cargo.toml
+done
 replace_in_file "Cargo.toml" 'description = "A production-ready Rust workspace template.*"' "description = \"$PROJECT_DESC\""
 replace_in_file "Cargo.toml" 'authors = \["Your Name"\]' "authors = [\"$AUTHOR\"]"
 replace_in_file "Cargo.toml" 'repository = "https://github.com/your-org/your-repo"' "repository = \"$REPO_URL\""
@@ -330,12 +349,19 @@ replace_in_file "crates/sample-app/README.md" 'rust-2026-template' "$PROJECT_NAM
 if [[ -f "fuzz/Cargo.toml" ]]; then
   log "Updating fuzz/Cargo.toml"
   replace_in_file "fuzz/Cargo.toml" 'rust-2026-template' "$PROJECT_NAME"
+  replace_literal "fuzz/Cargo.toml" \
+    'example-crate = { path = "../crates/example-crate"' \
+    "$PROJECT_NAME = { path = \"../crates/$PROJECT_NAME\""
+  replace_literal "fuzz/Cargo.toml" 'ignored = ["example-crate"]' "ignored = [\"$PROJECT_NAME\"]"
 fi
 
 # --- rewrite benchmarks/Cargo.toml (may be removed under --minimal) ---
 if [[ -f "benchmarks/Cargo.toml" ]]; then
   log "Updating benchmarks/Cargo.toml"
-  replace_in_file "benchmarks/Cargo.toml" 'rust-2026-template' "$PROJECT_NAME"
+  sedi '/rust-2026-template = { path = "\.\." }/d' benchmarks/Cargo.toml
+  replace_literal "benchmarks/Cargo.toml" \
+    'example-crate = { path = "../crates/example-crate"' \
+    "$PROJECT_NAME = { path = \"../crates/$PROJECT_NAME\""
 fi
 
 # --- rewrite CI workflows with repo-specific checks (files may be gone under --minimal) ---
@@ -379,6 +405,15 @@ EXAMPLES_DIR="examples/hello_world"
 if [[ -f "$EXAMPLES_DIR/src/main.rs" ]]; then
   log "Updating examples/hello_world/src/main.rs"
   replace_in_file "$EXAMPLES_DIR/src/main.rs" 'example_crate' "$CrateName"
+  replace_in_file "$EXAMPLES_DIR/src/main.rs" 'example-crate' "$PROJECT_NAME"
+fi
+
+EXAMPLES_TOML="examples/hello_world/Cargo.toml"
+if [[ -f "$EXAMPLES_TOML" ]]; then
+  log "Updating $EXAMPLES_TOML"
+  replace_literal "$EXAMPLES_TOML" \
+    'example-crate = { path = "../../crates/example-crate"' \
+    "$PROJECT_NAME = { path = \"../../crates/$PROJECT_NAME\""
 fi
 
 # --- validate ---


### PR DESCRIPTION
## Summary

- Fixes all three bugs reported in #260: stale `example-crate` dependency paths in `examples/hello_world/Cargo.toml`, `benchmarks/Cargo.toml`, `fuzz/Cargo.toml`, and duplicate `[package]` name collision
- Adds `replace_literal` function to handle `[` and `]` characters in sed patterns
- Strips root `[package]`, `[dependencies]`, `[dev-dependencies]`, and `[lints]` sections from workspace root to prevent "two packages named X" collisions
- Adds `.github/workflows/test-init-template.yml` — manual-trigger workflow verifying `init-template.sh` on ubuntu, macos, windows
- Updates `MIGRATION.md` to note the script handles renames automatically

## Testing

Verified locally:
- `init-template.sh --name pr-test` produces valid workspace
- `cargo check --workspace` passes
- No stale `example-crate` references in examples, benchmarks, or fuzz

The new CI workflow will also verify this on all three OS when triggered manually.

Fixes #260