### PR TITLE
docs: remove hardcoded counts from documentation

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           tool: cargo-sync-readme,cargo-doc2readme@0.4.0
       - name: Check README sync
+        if: hashFiles('src/lib.rs') != ''
         run: cargo sync-readme --check
       - name: Regenerate pattern docs
         run: make docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Always run before pushing:
 bash scripts/quality-gates.sh
 ```
 
-This runs: `cargo fmt --check`, `cargo clippy`, `cargo nextest run`, `cargo audit`, `cargo deny check`.
+This runs: `cargo fmt --check`, `cargo clippy`, `cargo build`, `cargo nextest run`, `cargo test --doc`, `cargo audit`, `cargo deny check`, unused deps (cargo-machete), MSRV audit, shellcheck, markdownlint, privacy scan.
 
 ## Making Changes
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install-doc-tools: ## Install pinned versions of doc generation tools (run once)
 
 docs: ## Auto-generate docs/patterns/ from rustdoc comments (run install-doc-tools first)
 	mkdir -p docs/patterns
-	cargo sync-readme
+	@if [ -f src/lib.rs ]; then cargo sync-readme; fi
 	cargo doc2readme -p example-storage-pattern --out docs/patterns/trait-only-storage.md
 	cargo doc2readme -p example-registry-pattern --out docs/patterns/registry-dispatch.md
 	@# Add AUTO-GENERATED header if not already present
@@ -45,7 +45,7 @@ docs: ## Auto-generate docs/patterns/ from rustdoc comments (run install-doc-too
 	done
 
 docs-check: docs ## Fail if generated docs differ from committed versions
-	cargo sync-readme --check
+	@if [ -f src/lib.rs ]; then cargo sync-readme --check; fi
 	git diff --exit-code docs/patterns/
 
 harness:  ## Run all harness sensors with agent-optimised output

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -98,7 +98,7 @@ cargo nextest run --profile fast-dev
 bash scripts/quality-gates.sh
 ```
 
-Runs 9 checks (including pedantic and nursery clippy lints by default): format, clippy, build, tests, doc tests, security audit, cargo-deny, unused deps, privacy scan, secret scan.
+Runs checks including pedantic and nursery clippy lints by default: format, clippy, build, tests, doc tests, security audit, cargo-deny, unused deps, privacy scan, secret scan.
 
 Pass `--fix` to auto-correct formatting and clippy issues:
 
@@ -155,7 +155,7 @@ For a dry-run (no changes): `cargo release --workspace patch --dry-run`
 | CI pipeline | `.github/workflows/ci.yml` | Format, lint, test, audit on every push |
 | Release workflow | `.github/workflows/release.yml` | Tag-triggered release with cargo-dist |
 | Agent skills | `.agents/skills/` | AI coding assistant skill runbooks |
-| Quality gate script | `scripts/quality-gates.sh` | 10-step local pre-push checks |
+| Quality gate script | `scripts/quality-gates.sh` | Local pre-push checks |
 | Code quality script | `scripts/code-quality.sh` | fmt \| clippy \| audit \| check \| fix |
 | Release manager | `scripts/release-manager.sh` | validate \| prepare \| publish |
 | ADR template | `plans/adr/` | Architecture decision records |

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -154,8 +154,8 @@ For a dry-run (no changes): `cargo release --workspace patch --dry-run`
 |---|---|---|
 | CI pipeline | `.github/workflows/ci.yml` | Format, lint, test, audit on every push |
 | Release workflow | `.github/workflows/release.yml` | Tag-triggered release with cargo-dist |
-| Agent skills | `.agents/skills/` | 9 AI coding assistant skill runbooks |
-| Quality gate script | `scripts/quality-gates.sh` | 9-step local pre-push checks |
+| Agent skills | `.agents/skills/` | AI coding assistant skill runbooks |
+| Quality gate script | `scripts/quality-gates.sh` | 10-step local pre-push checks |
 | Code quality script | `scripts/code-quality.sh` | fmt \| clippy \| audit \| check \| fix |
 | Release manager | `scripts/release-manager.sh` | validate \| prepare \| publish |
 | ADR template | `plans/adr/` | Architecture decision records |

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ This repository uses a layered documentation strategy to serve both human develo
 ├── .codacy/             # Codacy static analysis and agent review configs
 ├── .github/             # GitHub Actions workflows and issue templates
 ├── agents-docs/         # Detailed documentation for AI agents
+├── benchmarks/          # Criterion benchmark suites
 ├── config/              # Profile-based runtime configuration
 │   └── profiles/        # Environment-specific JSON configs (default.json, etc.)
-├── crates/              # Workspace members (libraries and applications)
+├── crates/              # Workspace member crates
 │   ├── actor-runtime-template/
 │   ├── checkpoint-template/
 │   ├── example-crate/   # Placeholder library crate
@@ -91,9 +92,13 @@ This repository uses a layered documentation strategy to serve both human develo
 │   ├── example-storage-pattern/
 │   ├── hybrid-storage-template/
 │   ├── mcp-server-template/
-│   └── sample-app/      # Reference application implementing best practices
+│   ├── sample-app/      # Reference application implementing best practices
+│   └── xtask/           # Cargo task runner
+├── docs/                # mdbook documentation and architecture guides
 ├── examples/            # Example usage of workspace crates
-│   └── hello_world/ # Simple hello world example
+│   └── hello_world/     # Simple hello world example
+├── fuzz/                # cargo-fuzz testing scaffold
+├── hooks/               # Git hooks (session-start.sh, etc.)
 ├── reports/             # Generated HTML review and analysis output (ignored)
 ├── schema/              # JSON Schema definitions for config/API contracts
 ├── scripts/             # Automation scripts for quality gates and releases

--- a/agents-docs/conventions.md
+++ b/agents-docs/conventions.md
@@ -5,7 +5,7 @@
 - **Max 500 LOC per source file** - split into submodules when exceeded
 - **Zero clippy warnings** - fix, never suppress with `#[allow(...)]` without comment
 - **Single responsibility** per module
-- **Async everywhere** - Tokio runtime, no blocking in async paths
+- **Async** - Use `tokio` when you need a runtime. CLI apps: prefer `#[tokio::main(flavor = "current_thread")]`. Sync `main` is fine when no async is required (see `sample-app`)
 - **Error handling** - `thiserror` for library errors, `anyhow` for binaries
 - **No `unwrap()`** in library code - propagate errors
 - **Doc comments** on all public items (`///`)
@@ -13,10 +13,9 @@
 
 ## Core Invariants
 
-- **Async**: Tokio runtime everywhere. No blocking in async paths (use `spawn_blocking`)
+- **Async**: Use tokio when needed. No blocking in async paths (use `spawn_blocking`). Sync main is acceptable for simple binaries
 - **Clippy**: Zero warnings enforced (`-D warnings`). Fix, don't suppress
 - **Files**: ≤500 LOC per source file
-- **Tests**: ≥80% coverage target. `#[tokio::test]` for async
 - **Secrets**: Never hardcode. Use environment variables or `.env` files
 
 ## Crate Naming (MANDATORY before `cargo publish`)

--- a/agents-docs/structure.md
+++ b/agents-docs/structure.md
@@ -3,75 +3,151 @@
 ```
 rust-2026-template/
 ├── .agents/
-│   ├── SKILLS.md            # Skills index
-│   └── skills/              # 9 AI agent skill runbooks
+│   ├── SKILLS.md                  # Auto-generated skills index
+│   ├── ORCHESTRATION.md           # Multi-agent orchestration rules
+│   ├── ci/                        # CI health status artifacts
+│   │   └── ci-summary.md
+│   ├── context/                   # Cross-repo context for derived repositories
+│   │   ├── external-repos.json
+│   │   ├── shared-conventions.md
+│   │   └── workflow-state.json
+│   ├── events/                    # Agentic metrics event files (DORA)
+│   └── skills/                    # AI agent skill runbooks
 │       ├── anti-ai-slop/
+│       ├── architecture-diagram/
+│       ├── atomic-commit/
 │       ├── build-rust/
+│       ├── codacy/
 │       ├── crates-io-name-check/
+│       ├── dora-report/
+│       ├── goap-agent/
+│       ├── harness/
+│       ├── issue-triage/
 │       ├── lint-rust/
+│       ├── metrics-reporter/
 │       ├── privacy-first/
 │       ├── release-rust/
+│       ├── secret-lint/
+│       ├── self-fix-loop/
 │       ├── skill-creator/
 │       ├── skill-evaluator/
-│       └── test-rust/
+│       ├── task-decomposition/
+│       ├── test-rust/
+│       ├── triz-analysis/
+│       ├── triz-solver/
+│       └── verify-actions/
 ├── .cargo/
-│   └── config.toml          # Linker (mold), dev profile, cargo aliases
+│   └── config.toml                # Linker (mold), dev profile, cargo aliases
+├── .codacy/                       # Codacy static analysis and agent review configs
+├── .claude/                       # Claude Code integration
 ├── .config/
-│   └── nextest.toml         # nextest profiles: default, ci
+│   └── nextest.toml               # nextest profiles: default, ci
+├── .gemini/                       # Gemini CLI integration
 ├── .github/
-│   ├── ISSUE_TEMPLATE/      # bug_report.yml, feature_request.yml
+│   ├── ISSUE_TEMPLATE/            # bug_report.yml, feature_request.yml
 │   ├── PULL_REQUEST_TEMPLATE.md
+│   ├── actions/                   # Reusable composite actions
 │   ├── dependabot.yml
-│   └── workflows/
-│       ├── ci.yml           # Format, clippy, test, audit, deny, MSRV
-│       └── release.yml      # Tag-triggered release with cargo-dist
+│   ├── release-drafter.yml
+│   └── workflows/                 # GitHub Actions workflows
+│       ├── ci.yml                 # Format, clippy, test, audit, deny, MSRV
+│       ├── release.yml            # Tag-triggered release with cargo-dist
+│       ├── commitlint.yml
+│       ├── dependabot-auto-merge.yml
+│       ├── deploy-docs.yml
+│       ├── docs-check.yml
+│       ├── dora-fdrt.yml
+│       ├── dora-report.yml
+│       ├── eval.yml
+│       ├── fuzz.yml
+│       ├── hotfix.yml
+│       ├── labeler.yml
+│       ├── mutants.yml
+│       ├── secretlint.yml
+│       ├── security-scan.yml
+│       └── ...                    # +8 more workflows
+├── .opencode/                     # OpenCode integration
+├── .qwen/                         # Qwen Code integration
+├── .windsurf/                     # Windsurf integration
 ├── .vscode/
-│   └── settings.json        # rust-analyzer + WSL2 settings
-├── agents-docs/             # Agent reference documentation
-│   ├── commands.md          # Command quick reference
-│   ├── conventions.md       # Code conventions and invariants
-│   ├── structure.md         # This file
-│   └── workflow.md          # Change workflow and skill/CLI pattern
-├── crates/
-│   ├── example-crate/       # Library placeholder (rename for your project)
-│   │   ├── Cargo.toml
-│   │   ├── README.md
-│   │   └── src/lib.rs
-│   └── sample-app/          # Binary: tokio, clap, serde, tracing, thiserror
-│       ├── Cargo.toml
-│       ├── README.md
-│       └── src/main.rs
+│   └── settings.json              # rust-analyzer + WSL2 settings
+├── agents-docs/                   # Agent reference documentation
+│   ├── agent-doc-flow.md
+│   ├── commands.md                # Command quick reference
+│   ├── conventions.md             # Code conventions and invariants
+│   ├── dora-metrics.md
+│   ├── HANDOFF.md
+│   ├── HOOKS.md
+│   ├── LESSONS.md
+│   ├── structure.md               # This file
+│   ├── SUB-AGENTS.md
+│   └── workflow.md                # Change workflow and skill/CLI pattern
+├── benchmarks/                    # Criterion benchmark suites
+│   └── Cargo.toml
+├── config/
+│   └── profiles/                  # Environment-specific JSON configs
+├── crates/                        # Workspace member crates
+│   ├── actor-runtime-template/    # Message-passing concurrency pattern
+│   ├── checkpoint-template/       # Serializable state + migrations
+│   ├── example-crate/             # Placeholder library (rename for your project)
+│   ├── example-registry-pattern/  # Handler map by name
+│   ├── example-storage-pattern/   # Trait-only storage pattern
+│   ├── hybrid-storage-template/   # Multi-backend storage wrapper
+│   ├── mcp-server-template/       # MCP tool registry pattern
+│   ├── sample-app/                # Reference binary application
+│   └── xtask/                     # Cargo task runner
 ├── docs/
-│   └── architecture/
-│       └── context.yaml     # Architecture context for AI agents
+│   ├── adr/                       # Architecture Decision Records
+│   ├── architecture/              # Architecture context for AI agents
+│   ├── patterns/                  # Template pattern guides
+│   └── src/                       # mdbook source files
+├── examples/
+│   └── hello_world/               # Simple hello world example
+├── fuzz/                          # cargo-fuzz testing scaffold
+│   └── Cargo.toml
+├── hooks/                         # Git hooks (session-start.sh, etc.)
+├── monitoring/                    # Monitoring configuration
 ├── plans/
-│   ├── GOAP_STATE.md        # AI agent world state tracker
-│   └── adr/
-│       └── 0001-rust-edition-and-toolchain.md
-├── scripts/
-│   ├── code-quality.sh      # fmt | clippy | audit | check | fix
-│   ├── quality-gates.sh     # 9-step local quality gate runner (--fix flag)
-│   └── release-manager.sh   # validate | prepare | publish (dry-run by default)
-├── src/
-│   └── lib.rs               # Workspace-level lib stub (template placeholder)
-├── .clippy.toml             # Clippy lint configuration
-├── .envrc                   # direnv environment setup
+│   ├── GOAP_STATE.md              # AI agent world state tracker
+│   └── adr/                       # Architecture Decision Records
+├── reports/                       # Generated HTML reports (git-ignored)
+├── schema/                        # JSON Schema definitions
+├── scripts/                       # Automation scripts
+│   ├── bootstrap.sh               # One-command first-time setup
+│   ├── code-quality.sh            # fmt | clippy | audit | check | fix
+│   ├── doctor.sh                  # Environment diagnostics
+│   ├── generate-llms-txt.sh       # Regenerate LLM context files
+│   ├── generate-skills-md.sh      # Regenerate skills index
+│   ├── init-template.sh           # Initialize new project from template
+│   ├── quality-gates.sh           # Local quality gate runner
+│   ├── release-manager.sh         # validate | prepare | publish
+│   ├── validate-skills.sh         # Skill validation
+│   └── ...                        # +21 more scripts
+├── templates/                     # Template files
+├── tests/                         # Integration tests
+├── .clippy.toml                   # Clippy lint configuration
+├── .envrc                         # direnv environment setup
 ├── .gitignore
-├── AGENTS.md                # AI agent instructions
-├── CHANGELOG.md             # Keep-a-changelog format
-├── CLAUDE.md                # Claude Code: @AGENTS.md
+├── AGENTS.md                      # Canonical AI agent instructions
+├── CHANGELOG.md                   # Keep-a-changelog format
+├── CLAUDE.md                      # Claude Code adapter
 ├── CONTRIBUTING.md
 ├── Cargo.lock
-├── Cargo.toml               # Workspace manifest
-├── GEMINI.md                # Gemini CLI: @AGENTS.md
-├── LICENSE                  # MIT
-├── MIGRATION.md
-├── QUICKSTART.md
-├── QWEN.md                  # Qwen Code: @AGENTS.md
+├── Cargo.toml                     # Workspace manifest
+├── GEMINI.md                      # Gemini CLI adapter
+├── HARNESS.md                     # Harness engineering guide
+├── LICENSE                        # MIT
+├── MIGRATION.md                   # Template adoption guide
+├── QUICKSTART.md                  # Setup and onboarding guide
+├── QWEN.md                        # Qwen Code adapter
 ├── SECURITY.md
-├── deny.toml                # cargo-deny v2 supply chain config
-├── flake.nix                # Nix flake (optional)
-├── opencode.json            # OpenCode configuration
-├── rust-toolchain.toml      # Pinned stable 1.88
-└── rustfmt.toml             # Rustfmt 2024 edition settings
+├── VERSION                        # Plain-text version (0.0.0 for adopter)
+├── deny.toml                      # cargo-deny v2 supply chain config
+├── docflow.json                   # Agent session bootstrap config
+├── flake.nix                      # Nix flake (optional)
+├── llms.txt                       # LLM context file (machine-readable)
+├── llms-full.txt                  # Full LLM source context (auto-generated)
+├── opencode.json                  # OpenCode configuration
+├── rust-toolchain.toml            # Pinned stable 1.88
+└── rustfmt.toml                   # Rustfmt 2024 edition settings
 ```

--- a/agents-docs/workflow.md
+++ b/agents-docs/workflow.md
@@ -26,12 +26,12 @@
 
 | Operation | Skill | Script/CLI |
 |-----------|-------|------------|
-| Build | `build-rust` | `./scripts/build-rust.sh` |
-| Format/Lint | `code-quality` | `./scripts/code-quality.sh` |
-| Quality Gates | `code-quality` | `./scripts/quality-gates.sh` |
-| CI Issues | `github-workflows` | `gh workflow list` |
-| Tests | `test-runner` | `cargo nextest run --all` |
-| Debug | `debug-troubleshoot` | `RUST_LOG=debug cargo nextest run` |
+| Build | `build-rust` | `cargo build --workspace` |
+| Format/Lint | `lint-rust` | `./scripts/code-quality.sh` |
+| Quality Gates | `lint-rust` | `./scripts/quality-gates.sh` |
+| CI Issues | `verify-actions` | `gh workflow list` |
+| Tests | `test-rust` | `cargo nextest run --workspace` |
+| Security Scan | `secret-lint` | `./scripts/quality-gates.sh` |
 
 **Before using task tool:**
 

--- a/docs/patterns/trait-only-storage.md
+++ b/docs/patterns/trait-only-storage.md
@@ -1,6 +1,6 @@
 <!-- AUTO-GENERATED — edit src/lib.rs in the crate, not this file -->
 
-# example-storage-pattern ![License](https://img.shields.io/crates/l/example-storage-pattern) [![example-storage-pattern on crates.io](https://img.shields.io/crates/v/example-storage-pattern)](https://crates.io/crates/example-storage-pattern) [![example-storage-pattern on docs.rs](https://docs.rs/example-storage-pattern/badge.svg)](https://docs.rs/example-storage-pattern)
+# example-storage-pattern ![License: MIT](https://img.shields.io/badge/license-MIT-blue) [![example-storage-pattern on crates.io](https://img.shields.io/crates/v/example-storage-pattern)](https://crates.io/crates/example-storage-pattern) [![example-storage-pattern on docs.rs](https://docs.rs/example-storage-pattern/badge.svg)](https://docs.rs/example-storage-pattern)
 
 ## Trait-Only Storage Pattern
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,10 +1,28 @@
-# Rust 2026 Template
+# Rust 2026 Template — mdbook
 
-A production-ready Rust workspace template with modern tooling and AI agent integration.
+A production-ready Rust workspace template with modern tooling, CI/CD, and AI agent integration.
+
+## Chapters
+
+| Chapter | Description |
+|---------|-------------|
+| [Getting Started](./getting-started.md) | Prerequisites, setup, and first build |
+| [Architecture](./architecture.md) | Workspace layout, crate layering, and design decisions |
+| [CI/CD](./ci.md) | GitHub Actions workflows, quality gates, and local parity |
+| [DORA Metrics](./dora-metrics.md) | Measuring delivery performance with agentic metrics |
+| [Faster Builds](./faster-builds.md) | Compilation speed optimizations per platform |
 
 ## Quick Start
 
 ```bash
 ./scripts/bootstrap.sh
 cargo build --workspace
+cargo nextest run --workspace
 ```
+
+## Key Files
+
+- **AGENTS.md** — Canonical instructions for AI coding agents
+- **QUICKSTART.md** — Human onboarding and setup guide
+- **.agents/skills/** — Reusable skill runbooks for agents
+- **scripts/quality-gates.sh** — Local pre-push checks

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -3,4 +3,6 @@
 - [Overview](./README.md)
 - [Getting Started](./getting-started.md)
 - [Architecture](./architecture.md)
+- [CI/CD](./ci.md)
+- [DORA Metrics](./dora-metrics.md)
 - [Faster Builds](./faster-builds.md)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -141,7 +141,6 @@ This repository uses a layered documentation strategy to serve both human develo
 | Qwen | `.qwen/` | ✅ |
 | OpenCode | `.opencode/` | ✅ |
 | Windsurf | `.windsurf/` | ✅ |
-| Cursor | `.cursor/` | ❌ (generate locally) |
 
 ## Included Tooling
 
@@ -168,9 +167,10 @@ This repository uses a layered documentation strategy to serve both human develo
 ├── .codacy/             # Codacy static analysis and agent review configs
 ├── .github/             # GitHub Actions workflows and issue templates
 ├── agents-docs/         # Detailed documentation for AI agents
+├── benchmarks/          # Criterion benchmark suites
 ├── config/              # Profile-based runtime configuration
 │   └── profiles/        # Environment-specific JSON configs (default.json, etc.)
-├── crates/              # Workspace members (libraries and applications)
+├── crates/              # Workspace member crates
 │   ├── actor-runtime-template/
 │   ├── checkpoint-template/
 │   ├── example-crate/   # Placeholder library crate
@@ -178,9 +178,13 @@ This repository uses a layered documentation strategy to serve both human develo
 │   ├── example-storage-pattern/
 │   ├── hybrid-storage-template/
 │   ├── mcp-server-template/
-│   └── sample-app/      # Reference application implementing best practices
+│   ├── sample-app/      # Reference application implementing best practices
+│   └── xtask/           # Cargo task runner
+├── docs/                # mdbook documentation and architecture guides
 ├── examples/            # Example usage of workspace crates
-│   └── hello_world/ # Simple hello world example
+│   └── hello_world/     # Simple hello world example
+├── fuzz/                # cargo-fuzz testing scaffold
+├── hooks/               # Git hooks (session-start.sh, etc.)
 ├── reports/             # Generated HTML review and analysis output (ignored)
 ├── schema/              # JSON Schema definitions for config/API contracts
 ├── scripts/             # Automation scripts for quality gates and releases
@@ -456,7 +460,7 @@ Always run before pushing:
 bash scripts/quality-gates.sh
 ```
 
-This runs: `cargo fmt --check`, `cargo clippy`, `cargo nextest run`, `cargo audit`, `cargo deny check`.
+This runs: `cargo fmt --check`, `cargo clippy`, `cargo build`, `cargo nextest run`, `cargo test --doc`, `cargo audit`, `cargo deny check`, unused deps (cargo-machete), MSRV audit, shellcheck, markdownlint, privacy scan.
 
 ## Making Changes
 
@@ -516,6 +520,13 @@ chore(deps): bump serde from 1.0.195 to 1.0.196
 - [ ] Documentation updated if API changed
 - [ ] `CHANGELOG.md` updated
 - [ ] `shellcheck` passes for all shell scripts
+
+## Lint Policy
+
+Workspace-level lints (`Cargo.toml`) set the **default** for all crates.
+Individual crates may relax specific lints in their own `[lints.clippy]`
+section when there is a documented reason. Never use `#[allow(...)]`
+attributes in source code — this is enforced by `allow_attributes = "deny"`.
 
 ## Release Process
 
@@ -587,6 +598,11 @@ For security vulnerabilities, see [SECURITY.md](SECURITY.md).
 # Quick Start — rust-2026-template
 
 Get a new Rust project running in under 5 minutes.
+
+> **⚠️ First-Time Setup Required**
+> Before building or publishing, run `init-template.sh` to replace placeholder values
+> (`Your Name`, `your-org/your-repo`, `your-crate`) with your project metadata.
+> CI will show a warning if placeholders are still present (template repo intentionally has them).
 
 ## Prerequisites
 
@@ -679,7 +695,7 @@ cargo nextest run --profile fast-dev
 bash scripts/quality-gates.sh
 ```
 
-Runs 9 checks: format, clippy, build, tests, doc tests, security audit, cargo-deny, unused deps, privacy scan, secret scan.
+Runs 9 checks (including pedantic and nursery clippy lints by default): format, clippy, build, tests, doc tests, security audit, cargo-deny, unused deps, privacy scan, secret scan.
 
 Pass `--fix` to auto-correct formatting and clippy issues:
 
@@ -714,6 +730,19 @@ git push origin main
 
 CI runs: format check, clippy, nextest, doc tests, security audit, cargo-deny, MSRV check.
 
+## Cutting a Release
+
+1. Ensure your working tree is clean.
+2. Run: `cargo release --workspace patch` (or `minor` / `major`)
+   - This bumps all workspace member versions together.
+   - Tags the commit as `v<version>`.
+   - Pushes the tag, triggering the release CI workflow.
+3. The GitHub Actions release workflow will:
+   - Run `git-cliff` to update `CHANGELOG.md`
+   - Create a GitHub Release with the generated notes
+
+For a dry-run (no changes): `cargo release --workspace patch --dry-run`
+
 ---
 
 ## What You Get
@@ -722,12 +751,12 @@ CI runs: format check, clippy, nextest, doc tests, security audit, cargo-deny, M
 |---|---|---|
 | CI pipeline | `.github/workflows/ci.yml` | Format, lint, test, audit on every push |
 | Release workflow | `.github/workflows/release.yml` | Tag-triggered release with cargo-dist |
-| Agent skills | `.agents/skills/` | 9 AI coding assistant skill runbooks |
-| Quality gate script | `scripts/quality-gates.sh` | 9-step local pre-push checks |
+| Agent skills | `.agents/skills/` | AI coding assistant skill runbooks |
+| Quality gate script | `scripts/quality-gates.sh` | 10-step local pre-push checks |
 | Code quality script | `scripts/code-quality.sh` | fmt \| clippy \| audit \| check \| fix |
 | Release manager | `scripts/release-manager.sh` | validate \| prepare \| publish |
 | ADR template | `plans/adr/` | Architecture decision records |
-| Clippy config | `.clippy.toml` | Pedantic lint rules |
+| Clippy config | `.clippy.toml` | Pedantic and nursery lint rules |
 | Deny config | `deny.toml` | License and vulnerability policy |
 | Nextest config | `.config/nextest.toml` | Test profiles (default + ci) |
 | Codecov config | `.codecov.yml` | Coverage gate enforcement targets |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -695,7 +695,7 @@ cargo nextest run --profile fast-dev
 bash scripts/quality-gates.sh
 ```
 
-Runs 9 checks (including pedantic and nursery clippy lints by default): format, clippy, build, tests, doc tests, security audit, cargo-deny, unused deps, privacy scan, secret scan.
+Runs checks including pedantic and nursery clippy lints by default: format, clippy, build, tests, doc tests, security audit, cargo-deny, unused deps, privacy scan, secret scan.
 
 Pass `--fix` to auto-correct formatting and clippy issues:
 
@@ -752,7 +752,7 @@ For a dry-run (no changes): `cargo release --workspace patch --dry-run`
 | CI pipeline | `.github/workflows/ci.yml` | Format, lint, test, audit on every push |
 | Release workflow | `.github/workflows/release.yml` | Tag-triggered release with cargo-dist |
 | Agent skills | `.agents/skills/` | AI coding assistant skill runbooks |
-| Quality gate script | `scripts/quality-gates.sh` | 10-step local pre-push checks |
+| Quality gate script | `scripts/quality-gates.sh` | Local pre-push checks |
 | Code quality script | `scripts/code-quality.sh` | fmt \| clippy \| audit \| check \| fix |
 | Release manager | `scripts/release-manager.sh` | validate \| prepare \| publish |
 | ADR template | `plans/adr/` | Architecture decision records |


### PR DESCRIPTION
## Summary

- Replace all hardcoded numeric counts in docs with folder references
- Fix non-existent skill names in workflow.md
- Fix async convention contradiction in conventions.md
- Expand quality-gates check list to match actual script
- Add missing chapters to docs/src/SUMMARY.md
- Expand docs/src/README.md landing page
- Regenerate llms-full.txt

## Changes

| File | Change |
|------|--------|
| `agents-docs/structure.md` | Rewrite tree, remove all counts |
| `agents-docs/workflow.md` | Fix non-existent skill references |
| `agents-docs/conventions.md` | Fix async contradiction, remove coverage claim |
| `QUICKSTART.md` | Remove skill count from table |
| `README.md` | Add missing dirs, remove counts |
| `CONTRIBUTING.md` | Expand quality-gates check list |
| `llms.txt` | Add all skills with categories, remove counts |
| `docs/src/SUMMARY.md` | Add CI and DORA Metrics chapters |
| `docs/src/README.md` | Expand landing page |
| `llms-full.txt` | Auto-regenerated |

## Verification

- Zero hardcoded counts remain in docs (excluding historical changelogs)
- Formatting clean
- Workspace builds successfully