### PR TITLE
feat(hotfix): add gh run watch to block DORA FDRT recovery until CI is green

### DIFF
--- a/.agents/skills/dora-report/SKILL.md
+++ b/.agents/skills/dora-report/SKILL.md
@@ -96,3 +96,18 @@ echo '{"timestamp":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","agent":"claude","skill":"
 - [ ] Running DORA report less than monthly (trends need data points)
 - [ ] Ignoring Lead Time for Changes (the hardest metric to improve)
 - [ ] Not tracking human_interventions in metrics (hides true agent performance)
+
+## GH CLI Usage
+
+Use `gh run watch` to gate DORA recovery recording on CI passing:
+
+```bash
+# Find latest CI run for a branch
+RUN_ID=$(gh run list --branch hotfix/my-fix --workflow ci.yml \
+  --limit 1 --json databaseId --jq '.[0].databaseId')
+
+# Block until CI completes; exits non-zero if CI fails
+gh run watch "$RUN_ID" --exit-status
+```
+
+This ensures FDRT recovery is only counted after a verified green build.

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read   # required for gh run list / gh run watch
     steps:
       - name: Record Hotfix Event
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
@@ -53,6 +54,30 @@ jobs:
 
             const fs = require('fs');
             fs.writeFileSync('dora-metrics.jsonl', JSON.stringify(event) + '\n');
+
+      - name: Wait for CI on hotfix branch
+        # Only applicable when triggered by a push to a hotfix branch
+        # (not when triggered by a PR merge, where CI already ran)
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find the most recent CI run for this branch and wait for it
+          RUN_ID=$(gh run list \
+            --branch "${{ github.ref_name }}" \
+            --workflow "ci.yml" \
+            --limit 1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "No CI run found for branch ${{ github.ref_name }} — skipping watch"
+            exit 0
+          fi
+
+          echo "Watching CI run $RUN_ID for branch ${{ github.ref_name }}..."
+          gh run watch "$RUN_ID" --exit-status
+          echo "CI passed ✔ Hotfix branch is green."
 
       - name: Upload DORA Metrics
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7

--- a/benchmarks/benches/checkpoint_bench.rs
+++ b/benchmarks/benches/checkpoint_bench.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, missing_docs)]
 
-use std::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
 
 fn is_invalid_app_name_current(app_name: &str) -> bool {
     app_name.chars().any(|c| {

--- a/benchmarks/benches/checkpoint_bench.rs
+++ b/benchmarks/benches/checkpoint_bench.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, missing_docs)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+use criterion::{Criterion, criterion_group, criterion_main};
 
 fn is_invalid_app_name_current(app_name: &str) -> bool {
     app_name.chars().any(|c| {

--- a/benchmarks/benches/sanitization_bench.rs
+++ b/benchmarks/benches/sanitization_bench.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, missing_docs)]
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+use criterion::{Criterion, criterion_group, criterion_main};
 use sample_app::{is_safe_char, sanitize_str};
 
 fn old_sanitize_str(s: &str) -> String {

--- a/benchmarks/benches/sanitization_bench.rs
+++ b/benchmarks/benches/sanitization_bench.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic, missing_docs)]
 
-use std::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
 use sample_app::{is_safe_char, sanitize_str};
+use std::hint::black_box;
 
 fn old_sanitize_str(s: &str) -> String {
     s.chars()


### PR DESCRIPTION
Added gh run watch gate to .github/workflows/hotfix.yml to block DORA FDRT recovery recording until CI has successfully completed, and documented the pattern in .agents/skills/dora-report/SKILL.md.

Fixes #273

---
*PR created automatically by Jules for task [9345732639384133512](https://jules.google.com/task/9345732639384133512) started by @d-oit*