### PR TITLE
feat(ci): add config-driven verification tiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,61 @@ jobs:
           path: reports/roast-report.json
 
   # ───────────────────────────────────────────────────
+  # Config-driven verification (issue #285): which checks run per trigger is decided by
+  # config/xtask.json — not by magic values in this YAML. PRs run the fast `pull-request`
+  # tier; pushes to protected branches run the deep `protected-branch` tier. The GHA job
+  # summary also prints the resolved plan for every configured tier.
+  quality-gate:
+    name: Quality Gate (${{ github.event_name == 'pull_request' && 'pull-request' || 'protected-branch' }})
+    needs: [changes]
+    if: >
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.code == 'true' ||
+      needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: ./.github/actions/setup-rust
+      - name: Install verification tooling
+        uses: taiki-e/install-action@91ddec75689c4c78665b598d188dc821c5a43e5c  # v2
+        with:
+          tool: cargo-nextest,cargo-audit,cargo-deny,cargo-machete
+      - name: Install shellcheck and markdownlint
+        run: |
+          sudo apt-get install -y shellcheck
+          npm install -g markdownlint-cli2
+      - name: Publish configured verification tiers
+        run: |
+          echo "### Verification tiers (config/xtask.json)" >> "$GITHUB_STEP_SUMMARY"
+          for tier in pull-request protected-branch scheduled release; do
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "#### Tier \`$tier\`" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cargo run --quiet --bin xtask -- quality plan --tier "$tier" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          done
+      - name: Run trigger tier
+        run: |
+          TIER=pull-request
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            TIER=protected-branch
+          fi
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          echo "Running config-driven quality tier: $TIER"
+          if [ -n "$BASE" ]; then
+            cargo run --quiet --bin xtask -- quality run --tier "$TIER" --changed-from "$BASE"
+          else
+            cargo run --quiet --bin xtask -- quality run --tier "$TIER"
+          fi
+
+  # ───────────────────────────────────────────────────
   ci-success:
     name: CI Success
     needs:
@@ -417,6 +472,7 @@ jobs:
       - version-check
       - msrv
       - roast
+      - quality-gate
     runs-on: ubuntu-latest
     if: always()
     permissions:
@@ -543,6 +599,7 @@ jobs:
             "${{ needs.version-check.result }}"
             "${{ needs.msrv.result }}"
             "${{ needs.roast.result }}"
+            "${{ needs.quality-gate.result }}"
           )
           for res in "${results[@]}"; do
             if [[ "$res" == "failure" || "$res" == "cancelled" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "#### Tier \`$tier\`" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cargo run --quiet --bin xtask -- quality plan --tier "$tier" >> "$GITHUB_STEP_SUMMARY"
+            cargo run --quiet -p xtask --bin xtask -- quality plan --tier "$tier" >> "$GITHUB_STEP_SUMMARY"
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           done
       - name: Run trigger tier
@@ -450,9 +450,9 @@ jobs:
           fi
           echo "Running config-driven quality tier: $TIER"
           if [ -n "$BASE" ]; then
-            cargo run --quiet --bin xtask -- quality run --tier "$TIER" --changed-from "$BASE"
+            cargo run --quiet -p xtask --bin xtask -- quality run --tier "$TIER" --changed-from "$BASE"
           else
-            cargo run --quiet --bin xtask -- quality run --tier "$TIER"
+            cargo run --quiet -p xtask --bin xtask -- quality run --tier "$TIER"
           fi
 
   # ───────────────────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ Derived repositories should check `.agents/context/` for shared conventions and 
 - **Async Safety:** Avoid blocking calls; use `spawn_blocking` when necessary.
 - **Tracing:** Minimize CLI tracing metadata (thread IDs/names) unless high-concurrency.
 - **Quality SSOT:** Prefer `./scripts/quality-gates.sh` before push. `cargo run -p xtask quality-gates` delegates to that script.
+- **Verification tiers:** Which checks run for each lifecycle trigger (pull request / protected branch / scheduled / release) is configured in `config/xtask.json` (`tiers` map: `pull-request`, `protected-branch`, `scheduled`, `release`) — not in workflow YAML. Override per run via `xtask quality run --tier <name>` or `$XTASK_TIER`. Legacy names `fast-pr` and `full-gate`/`all` are aliases for `pull-request` and `protected-branch`.
 
 ### Security & Configuration
 - **Hardening:** Enforce `#[serde(deny_unknown_fields)]` on config structs.

--- a/config/xtask.json
+++ b/config/xtask.json
@@ -1,0 +1,72 @@
+{
+  "env_var_name": "XTASK_TIER",
+  "default_tier": "protected-branch",
+  "tiers": {
+    "pull-request": {
+      "checks": [
+        "LocLimits",
+        "Fmt",
+        "Clippy",
+        "Build",
+        "Test",
+        "DocTest",
+        "PrivacyCheck",
+        "SecretScan"
+      ]
+    },
+    "protected-branch": {
+      "checks": [
+        "LocLimits",
+        "Fmt",
+        "Clippy",
+        "Build",
+        "Test",
+        "DocTest",
+        "Audit",
+        "Deny",
+        "Machete",
+        "Msrv",
+        "ShellCheck",
+        "MarkdownLint",
+        "PrivacyCheck",
+        "SecretScan",
+        "WorkflowValidation",
+        "CiStatusArtifact"
+      ]
+    },
+    "scheduled": {
+      "checks": [
+        "SkillValidation",
+        "AdrCompliance",
+        "SkillEvals",
+        "RoastScorer",
+        "LlmContext",
+        "Clippy",
+        "Test",
+        "Audit",
+        "Deny",
+        "Machete",
+        "Msrv"
+      ]
+    },
+    "release": {
+      "checks": [
+        "Clippy",
+        "Build",
+        "Test",
+        "DocTest",
+        "Audit",
+        "Deny",
+        "Machete",
+        "Msrv",
+        "WorkflowValidation",
+        "PrivacyCheck",
+        "SecretScan"
+      ]
+    }
+  },
+  "lint_thresholds": {
+    "max_lines_per_file": 500,
+    "clippy_warnings_as_errors": true
+  }
+}

--- a/crates/xtask/src/config.rs
+++ b/crates/xtask/src/config.rs
@@ -1,6 +1,8 @@
 //! Xtask Configuration and Custom Errors.
 
+use crate::quality::QualityCheck;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
@@ -59,14 +61,30 @@ pub struct LintThresholds {
     pub clippy_warnings_as_errors: bool,
 }
 
+/// Definition of one verification tier: the ordered set of checks it runs.
+///
+/// Tiers are the portable way to say *which* checks belong to *which* lifecycle
+/// trigger (pull request, protected branch, scheduled run, release) without
+/// embedding project-specific names or magic values in workflow YAML.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct TierDef {
+    /// Quality checks this tier runs, in execution order.
+    pub checks: Vec<QualityCheck>,
+}
+
 /// The main strongly typed configuration structure.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct XtaskConfig {
     /// Name of env variable that can override the default quality tier (e.g. "`XTASK_TIER`").
     pub env_var_name: String,
-    /// Default quality tier to run if neither `--tier` nor the env override is set (e.g. "full-gate").
+    /// Default quality tier to run if neither `--tier` nor the env override is set (e.g. "protected-branch").
     pub default_tier: String,
+    /// Named verification tiers (e.g. "pull-request", "protected-branch"). Falls back to
+    /// built-in defaults for names not present here, so a minimal config still works.
+    #[serde(default)]
+    pub tiers: BTreeMap<String, TierDef>,
     /// Configurable thresholds.
     pub lint_thresholds: LintThresholds,
 }
@@ -75,12 +93,102 @@ impl Default for XtaskConfig {
     fn default() -> Self {
         Self {
             env_var_name: "XTASK_TIER".to_string(),
-            default_tier: "full-gate".to_string(),
+            default_tier: "protected-branch".to_string(),
+            tiers: Self::builtin_tiers(),
             lint_thresholds: LintThresholds {
                 max_lines_per_file: 500,
                 clippy_warnings_as_errors: true,
             },
         }
+    }
+}
+
+impl XtaskConfig {
+    /// The portable, project-agnostic tier sets. Named after lifecycle triggers, not after any
+    /// specific repository: adopters add or redefine tiers in `config/xtask.json` without
+    /// touching workflow YAML.
+    fn builtin_tiers() -> BTreeMap<String, TierDef> {
+        use QualityCheck as Q;
+        let mut tiers = BTreeMap::new();
+        // Fast correctness gate for every pull request (no external security tooling required).
+        tiers.insert(
+            "pull-request".to_string(),
+            TierDef {
+                checks: vec![
+                    Q::LocLimits,
+                    Q::Fmt,
+                    Q::Clippy,
+                    Q::Build,
+                    Q::Test,
+                    Q::DocTest,
+                    Q::PrivacyCheck,
+                    Q::SecretScan,
+                ],
+            },
+        );
+        // Deep merge gate for protected branches: security/dependency policy plus the PR tier.
+        tiers.insert(
+            "protected-branch".to_string(),
+            TierDef {
+                checks: vec![
+                    Q::LocLimits,
+                    Q::Fmt,
+                    Q::Clippy,
+                    Q::Build,
+                    Q::Test,
+                    Q::DocTest,
+                    Q::Audit,
+                    Q::Deny,
+                    Q::Machete,
+                    Q::Msrv,
+                    Q::ShellCheck,
+                    Q::MarkdownLint,
+                    Q::PrivacyCheck,
+                    Q::SecretScan,
+                    Q::WorkflowValidation,
+                    Q::CiStatusArtifact,
+                ],
+            },
+        );
+        // Expensive / repo-specific checks that only make sense on a schedule.
+        tiers.insert(
+            "scheduled".to_string(),
+            TierDef {
+                checks: vec![
+                    Q::SkillValidation,
+                    Q::AdrCompliance,
+                    Q::SkillEvals,
+                    Q::RoastScorer,
+                    Q::LlmContext,
+                    Q::Clippy,
+                    Q::Test,
+                    Q::Audit,
+                    Q::Deny,
+                    Q::Machete,
+                    Q::Msrv,
+                ],
+            },
+        );
+        // Pre-release gate.
+        tiers.insert(
+            "release".to_string(),
+            TierDef {
+                checks: vec![
+                    Q::Clippy,
+                    Q::Build,
+                    Q::Test,
+                    Q::DocTest,
+                    Q::Audit,
+                    Q::Deny,
+                    Q::Machete,
+                    Q::Msrv,
+                    Q::WorkflowValidation,
+                    Q::PrivacyCheck,
+                    Q::SecretScan,
+                ],
+            },
+        );
+        tiers
     }
 }
 
@@ -112,10 +220,15 @@ impl XtaskConfig {
                 message: format!("Failed to read config file: {e}"),
             })?;
 
-        let config: Self =
+        let mut config: Self =
             serde_json::from_str(&content).map_err(|e| XtaskError::InvalidConfig {
                 message: format!("Failed to parse config JSON: {e}"),
             })?;
+        // A config that omits `tiers` (serializer default = empty) must still get the portable
+        // built-in tier sets so a minimal config keeps working.
+        if config.tiers.is_empty() {
+            config.tiers = Self::builtin_tiers();
+        }
         Ok(config)
     }
 }
@@ -129,19 +242,27 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = XtaskConfig::default();
-        assert_eq!(config.default_tier, "full-gate");
+        assert_eq!(config.default_tier, "protected-branch");
         assert_eq!(config.env_var_name, "XTASK_TIER");
         assert_eq!(config.lint_thresholds.max_lines_per_file, 500);
+        for tier in ["pull-request", "protected-branch", "scheduled", "release"] {
+            assert!(
+                config.tiers.contains_key(tier),
+                "builtin tier {tier} must exist"
+            );
+        }
     }
 
     #[test]
     fn test_load_non_existent_file() {
         let result = XtaskConfig::load_from_file("non-existent-file.json").unwrap();
-        assert_eq!(result.default_tier, "full-gate");
+        assert_eq!(result.default_tier, "protected-branch");
+        assert_eq!(result.tiers.len(), 4);
     }
 
     #[test]
-    fn test_load_valid_file() {
+    fn test_load_valid_file_without_tiers() {
+        // A config without a `tiers` key still loads (backwards compatible via serde default).
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("valid-xtask-config.json");
         let mut file = File::create(&path).unwrap();
@@ -152,5 +273,26 @@ mod tests {
         assert_eq!(result.env_var_name, "TEST_TIER");
         assert_eq!(result.lint_thresholds.max_lines_per_file, 300);
         assert!(!result.lint_thresholds.clippy_warnings_as_errors);
+        // Falls back to built-in tiers.
+        assert_eq!(result.tiers.len(), 4);
+    }
+
+    #[test]
+    fn test_load_custom_tier_overrides_builtin() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("custom-tiers.json");
+        std::fs::write(
+            &path,
+            r#"{"env_var_name":"XTASK_TIER","default_tier":"ci-smoke","tiers":{"ci-smoke":{"checks":["Fmt","Clippy"]}},"lint_thresholds":{"max_lines_per_file":500,"clippy_warnings_as_errors":true}}"#,
+        )
+        .unwrap();
+        let result = XtaskConfig::load_from_file(&path).unwrap();
+        assert_eq!(
+            result.tiers["ci-smoke"].checks,
+            vec![
+                crate::quality::QualityCheck::Fmt,
+                crate::quality::QualityCheck::Clippy
+            ]
+        );
     }
 }

--- a/crates/xtask/src/quality.rs
+++ b/crates/xtask/src/quality.rs
@@ -99,46 +99,18 @@ pub fn plan_checks(
     // Tier precedence: explicit `--tier` > `$XTASK_TIER` env override > config default.
     let env_tier = std::env::var(&config.env_var_name).ok();
     let selected_tier = tier.or(env_tier.as_deref()).unwrap_or(&config.default_tier);
-    let mut checks = match selected_tier {
-        "fast-pr" => vec![
-            QualityCheck::LocLimits,
-            QualityCheck::Fmt,
-            QualityCheck::Clippy,
-            QualityCheck::Build,
-            QualityCheck::Test,
-            QualityCheck::DocTest,
-            QualityCheck::PrivacyCheck,
-            QualityCheck::SecretScan,
-        ],
-        "full-gate" | "all" => vec![
-            QualityCheck::LocLimits,
-            QualityCheck::SkillValidation,
-            QualityCheck::AdrCompliance,
-            QualityCheck::Fmt,
-            QualityCheck::Clippy,
-            QualityCheck::Build,
-            QualityCheck::Test,
-            QualityCheck::DocTest,
-            QualityCheck::Audit,
-            QualityCheck::Deny,
-            QualityCheck::Machete,
-            QualityCheck::Msrv,
-            QualityCheck::ShellCheck,
-            QualityCheck::MarkdownLint,
-            QualityCheck::PrivacyCheck,
-            QualityCheck::SecretScan,
-            QualityCheck::WorkflowValidation,
-            QualityCheck::SkillEvals,
-            QualityCheck::LlmContext,
-            QualityCheck::CiStatusArtifact,
-            QualityCheck::RoastScorer,
-        ],
-        _ => {
-            return Err(XtaskError::InvalidConfig {
-                message: format!("Unsupported quality tier: {selected_tier}"),
-            });
-        }
+    // Canonical tier names; keep the legacy names as aliases for backwards compatibility.
+    let canonical_tier = match selected_tier {
+        "fast-pr" => "pull-request",
+        "full-gate" | "all" => "protected-branch",
+        other => other,
     };
+    let Some(def) = config.tiers.get(canonical_tier) else {
+        return Err(XtaskError::InvalidConfig {
+            message: format!("Unsupported or unconfigured quality tier: {selected_tier}"),
+        });
+    };
+    let mut checks = def.checks.clone();
 
     if let Some(only_str) = only {
         let only_checks: Vec<&str> = only_str.split(',').map(str::trim).collect();
@@ -449,5 +421,57 @@ mod tests {
         assert_eq!(checks.len(), 2);
         assert!(checks.contains(&QualityCheck::Fmt));
         assert!(checks.contains(&QualityCheck::Clippy));
+    }
+
+    #[test]
+    fn test_plan_checks_canonical_tiers() {
+        let config = XtaskConfig::default();
+        // pull-request is the fast correctness tier.
+        let pr = plan_checks(&config, Some("pull-request"), None, None).unwrap();
+        assert!(pr.contains(&QualityCheck::Test));
+        assert!(!pr.contains(&QualityCheck::Deny));
+        // protected-branch is the deep merge gate.
+        let merge = plan_checks(&config, Some("protected-branch"), None, None).unwrap();
+        assert!(merge.contains(&QualityCheck::Deny));
+        assert!(merge.contains(&QualityCheck::Audit));
+        // scheduled carries the expensive eval/roast checks, not the PR-tier trivia.
+        let scheduled = plan_checks(&config, Some("scheduled"), None, None).unwrap();
+        assert!(scheduled.contains(&QualityCheck::RoastScorer));
+        // release is the pre-release security + build gate.
+        let release = plan_checks(&config, Some("release"), None, None).unwrap();
+        assert!(release.contains(&QualityCheck::Audit));
+    }
+
+    #[test]
+    fn test_plan_checks_legacy_aliases() {
+        let config = XtaskConfig::default();
+        let fast = plan_checks(&config, Some("fast-pr"), None, None).unwrap();
+        let pr = plan_checks(&config, Some("pull-request"), None, None).unwrap();
+        assert_eq!(fast, pr);
+        let full = plan_checks(&config, Some("full-gate"), None, None).unwrap();
+        let all = plan_checks(&config, Some("all"), None, None).unwrap();
+        let merge = plan_checks(&config, Some("protected-branch"), None, None).unwrap();
+        assert_eq!(full, merge);
+        assert_eq!(all, merge);
+    }
+
+    #[test]
+    fn test_plan_checks_unknown_tier_is_error() {
+        let config = XtaskConfig::default();
+        let err = plan_checks(&config, Some("no-such-tier"), None, None).unwrap_err();
+        assert!(err.to_string().contains("no-such-tier"));
+    }
+
+    #[test]
+    fn test_plan_checks_custom_tier_from_config() {
+        let mut config = XtaskConfig::default();
+        config.tiers.insert(
+            "ci-smoke".to_string(),
+            crate::config::TierDef {
+                checks: vec![QualityCheck::Fmt, QualityCheck::Clippy],
+            },
+        );
+        let checks = plan_checks(&config, Some("ci-smoke"), None, None).unwrap();
+        assert_eq!(checks, vec![QualityCheck::Fmt, QualityCheck::Clippy]);
     }
 }

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -9,4 +9,4 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 1
 
 # Forward arguments to cargo xtask quality run
-exec cargo run --bin xtask -- quality run "$@"
+exec cargo run -p xtask --bin xtask -- quality run "$@"


### PR DESCRIPTION
## Summary

Implements #285: makes the CI verification *policy* a typed, portable configuration instead of magic values in workflow YAML.

### What changed
- **`config/xtask.json`** (new, SSOT): typed `tiers` map defining which quality checks run per lifecycle trigger — `pull-request`, `protected-branch`, `scheduled`, `release`. No project-specific names/org settings in YAML.
- **`XtaskConfig`**: configurable `tiers` with portable built-in defaults (backfilled when a minimal config omits `tiers`, backwards compatible); validated via `#[serde(deny_unknown_fields)]`.
- **`plan_checks`**: resolves tiers from config, not a hardcoded match. Legacy `fast-pr` → `pull-request`, `full-gate`/`all` → `protected-branch` kept as aliases.
- **CI**: new `quality-gate` job runs the trigger-driven tier (PR → `pull-request`, push → `protected-branch`) and publishes all four tier plans to the job summary; wired into `ci-success`.
- **Docs**: AGENTS.md documents the tier map + `--tier`/`$XTASK_TIER` overrides.

### Design notes
- Lifecycle-based, project-agnostic split: PR = fast correctness; protected-branch = deep merge gate (audit/deny/machete/shellcheck/markdownlint); scheduled = expensive eval/roast; release = pre-release security+build.
- `protected-branch` tier validated locally end-to-end (all 16 checks pass).

### Verification
- `cargo fmt` + `clippy -D warnings` clean; 25/25 xtask tests (new: tier config, aliases, unknown-tier error, custom-tier override).
- `yamllint` clean on `ci.yml`.