### PR TITLE
feat(init,ci): add validated project profiles and CI telemetry

### DIFF
--- a/.agents/ci/README.md
+++ b/.agents/ci/README.md
@@ -1,0 +1,24 @@
+# `.agents/ci` — CI Status & Telemetry Artifacts
+
+This directory holds the artifacts the quality gate produces and CI publishes.
+
+## Files
+
+| Path | Kind | Content |
+|---|---|---|
+| `ci-status.json` | Status | Consolidated result of the last quality gate run (`QualityReport`). Committed by CI on `main`. |
+| `ci-summary.md` | Status | Human-readable Markdown rendition of `ci-status.json`. |
+| `quality-run.json` | Telemetry | Schema-versioned telemetry for the last run: tier, plan source, scope, per-stage timing/skip reasons, toolchain versions (see `schema/ci-telemetry.schema.json`). Uploaded as a GH Actions artifact, not committed. |
+| `quality-summary.md` | Telemetry | Readable summary of `quality-run.json`, also appended to the job summary. |
+
+## Lifecycle
+
+- Both `ci-status.json` and `ci-summary.md` are **committed to `main`** by the CI
+  `ci-success` job (so the default branch always shows the last gate result).
+- `quality-run.json` / `quality-summary.md` are **volatile artifacts**: generated on every
+  run, uploaded by the `quality-gate` job, and never committed (see `.gitignore`).
+
+## Disabling telemetry
+
+Set `enabled = false` in `config/ci/telemetry.toml`. The gate still writes
+`ci-status.json`/`ci-summary.md`, but stops emitting the telemetry pair.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,6 +454,13 @@ jobs:
           else
             cargo run --quiet -p xtask --bin xtask -- quality run --tier "$TIER"
           fi
+      - name: Upload CI telemetry
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ci-telemetry
+          path: .agents/ci/quality-run.json
+          if-no-files-found: warn
 
   # ───────────────────────────────────────────────────
   ci-success:

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ dist/
 /ci-status.json
 /ci-summary.md
 
+# Volatile CI telemetry artifacts (uploaded as GH Actions artifacts, not committed)
+.agents/ci/quality-run.json
+.agents/ci/quality-summary.md
+
 # cargo-fuzz artifacts
 fuzz/corpus/
 fuzz/artifacts/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ thiserror = "2"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -24,19 +24,22 @@ git clone https://github.com/YOUR_USER/YOUR_REPO.git
 cd YOUR_REPO
 ```
 
-### Recommended: minimal init (most apps)
+### Recommended: use a project profile (most apps)
 
 ```bash
-./scripts/init-template.sh --minimal \
+./scripts/init-template.sh --profile minimal \
   --name your-crate-name \
   --description "Your description" \
   --author "Your Name" \
   --repo YOUR_USER/YOUR_REPO
 ```
 
-`--minimal` keeps `sample-app` + your renamed lib crate + `xtask`, and removes
-optional pattern crates (MCP, actor, storage demos, …) plus optional workflows
-(DORA, mutants, eval, …). Core CI/security workflows stay.
+Profiles are validated blueprints in `config/template-profiles/` (issue #286):
+`minimal`, `library`, `cli`, `service`, `workspace`, `ai-agent` choose which crates,
+workflows, and CI-tier default the generated project keeps. `--minimal` is shorthand
+for `--profile minimal` (keeps `sample-app` + your renamed lib crate + `xtask`; drops
+optional pattern crates and heavy workflows). See
+[docs/template-profiles.md](docs/template-profiles.md) for the selection table.
 
 **Versions:** leave `VERSION` / workspace version at `0.0.0` until you ship.
 Template release notes (`v0.3.x`) are only in `.template/CHANGELOG-TEMPLATE.md`.

--- a/README.md
+++ b/README.md
@@ -134,8 +134,32 @@ Real feature flags live on member crates that implement them, for example:
 | `hybrid-storage-template` | `sqlite` | Fail-closed SQLite **stub** (not production) |
 | `hybrid-storage-template` | `kv` | redb key-value backend |
 
-Pattern selection: [docs/patterns/README.md](docs/patterns/README.md). For a slim
-app workspace, run `./scripts/init-template.sh --minimal …`.
+Pattern selection: [docs/patterns/README.md](docs/patterns/README.md).
+
+## Project Profiles
+
+Choose a validated blueprint from `config/template-profiles/` that shapes the generated
+workspace: which crates stay, which workflows run, and the default CI tier.
+
+| Profile | Best for | Keeps |
+|---|---|---|
+| `minimal` | Small app | `sample-app` + renamed lib crate + `xtask`; drops pattern crates, benchmarks, fuzz, heavy workflows |
+| `library` | Reusable library | renamed lib crate + `xtask` + workspace tests |
+| `cli` | Binary tool | `sample-app` + renamed lib crate + `xtask` + tests |
+| `service` | Long-running service | actor/storage/registry patterns + `xtask` |
+| `workspace` | Full reference | every crate, benchmark, and workflow |
+| `ai-agent` | Agent-centric dev | `sample-app` + lib crate + `xtask` + agent tooling |
+
+```bash
+./scripts/init-template.sh --profile library --name my-lib
+# equivalent xtask commands
+cargo run -p xtask --bin xtask -- template init --profile minimal --name my-app
+cargo run -p xtask --bin xtask -- template validate-profile --profile config/template-profiles/library.toml
+cargo run -p xtask --bin xtask -- template inspect --profile service
+```
+
+`--minimal` remains a shorthand for `--profile minimal`. Full detail:
+[docs/template-profiles.md](docs/template-profiles.md).
 
 ## Benchmarks
 

--- a/config/ci/telemetry.toml
+++ b/config/ci/telemetry.toml
@@ -1,0 +1,14 @@
+# CI telemetry configuration (issue #289).
+# Budgets and behaviour live here — not in application logic — so adopters can
+# tune, disable, or walk back telemetry without touching xtask source.
+# Schema: schema/ci-telemetry.schema.json  (artifact schema_version = 1)
+
+enabled = true
+detail = "full"                 # "minimal" or "full" (minimal omits per-stage detail in summary)
+retention_days = 7              # how long CI should retain the telemetry artifact
+summary_path = ".agents/ci/quality-summary.md"
+artifact_path = ".agents/ci/quality-run.json"
+
+[budgets]
+# Surface a warning in the summary when a single stage exceeds this budget.
+max_stage_duration_ms = 600000

--- a/config/template-profiles/ai-agent.toml
+++ b/config/template-profiles/ai-agent.toml
@@ -1,0 +1,43 @@
+# AI-agent profile — lean workspace tuned for agent-centric development.
+# Keeps the app crate + lib + xtask and the agent/skills tooling workflows.
+[metadata]
+id = "ai-agent"
+display_name = "AI-Agent Project"
+description = "Lean workspace for agent-centric development: app, library, and agent tooling."
+
+[workspace]
+include_crates = [
+  "crates/example-crate",
+  "crates/sample-app",
+  "crates/xtask",
+  "crates/workspace-tests",
+]
+exclude_paths = [
+  "benchmarks",
+  "fuzz",
+  ".template",
+  "docs/patterns",
+]
+exclude_workflows = [
+  "cleanup-ci-status.yml",
+  "deploy-docs.yml",
+  "dora-fdrt.yml",
+  "fuzz.yml",
+  "labeler.yml",
+  "mutants.yml",
+  "patch-release-on-label.yml",
+  "sync-labels.yml",
+  "update-architecture-diagram.yml",
+]
+
+[ci]
+default_tier = "pull-request"
+
+[post_init]
+checklist = [
+  "set-package-metadata",
+  "choose-cargo-lock-policy",
+  "configure-license-policy",
+  "configure-branch-protection",
+  "configure-agent-skill-index",
+]

--- a/config/template-profiles/cli.toml
+++ b/config/template-profiles/cli.toml
@@ -1,0 +1,45 @@
+# CLI profile — binary-first workspace with an app crate and a supporting library.
+[metadata]
+id = "cli"
+display_name = "Rust CLI"
+description = "Binary-first workspace: app crate plus a supporting library and tests."
+
+[workspace]
+include_crates = [
+  "crates/example-crate",
+  "crates/sample-app",
+  "crates/xtask",
+  "crates/workspace-tests",
+]
+exclude_paths = [
+  "benchmarks",
+  "fuzz",
+  ".template",
+  "docs/patterns",
+]
+exclude_workflows = [
+  "cleanup-ci-status.yml",
+  "deploy-docs.yml",
+  "dora-fdrt.yml",
+  "dora-report.yml",
+  "eval.yml",
+  "fuzz.yml",
+  "labeler.yml",
+  "mutants.yml",
+  "patch-release-on-label.yml",
+  "skills-evaluation.yml",
+  "sync-labels.yml",
+  "update-architecture-diagram.yml",
+]
+
+[ci]
+default_tier = "protected-branch"
+
+[post_init]
+checklist = [
+  "set-package-metadata",
+  "choose-cargo-lock-policy",
+  "configure-license-policy",
+  "configure-branch-protection",
+  "generate-cli-manpage",
+]

--- a/config/template-profiles/library.toml
+++ b/config/template-profiles/library.toml
@@ -1,0 +1,45 @@
+# Library profile — reusable library with a strict public API surface.
+# Keeps: the renamed example lib + xtask + workspace tests + local app example for doc tests.
+[metadata]
+id = "library"
+display_name = "Rust Library"
+description = "Reusable library with strict public API and package checks."
+
+[workspace]
+include_crates = [
+  "crates/example-crate",
+  "crates/xtask",
+  "crates/workspace-tests",
+]
+exclude_paths = [
+  "benchmarks",
+  "fuzz",
+  ".template",
+  "docs/patterns",
+]
+exclude_workflows = [
+  "cleanup-ci-status.yml",
+  "deploy-docs.yml",
+  "dora-fdrt.yml",
+  "dora-report.yml",
+  "eval.yml",
+  "fuzz.yml",
+  "labeler.yml",
+  "mutants.yml",
+  "patch-release-on-label.yml",
+  "skills-evaluation.yml",
+  "sync-labels.yml",
+  "update-architecture-diagram.yml",
+]
+
+[ci]
+default_tier = "protected-branch"
+
+[post_init]
+checklist = [
+  "set-package-metadata",
+  "choose-cargo-lock-policy",
+  "configure-license-policy",
+  "configure-branch-protection",
+  "declare-public-api-surface",
+]

--- a/config/template-profiles/minimal.toml
+++ b/config/template-profiles/minimal.toml
@@ -1,0 +1,46 @@
+# Minimal profile — the smallest buildable workspace.
+# Keeps: one app crate (sample-app) + the renamed example lib (example-crate) + xtask + tests.
+# Removes: optional pattern crates, benchmarks, fuzz, and heavy CI workflows.
+[metadata]
+id = "minimal"
+display_name = "Minimal Rust App"
+description = "Smallest buildable workspace: one app plus one library, no pattern crates."
+
+[workspace]
+include_crates = [
+  "crates/example-crate",
+  "crates/sample-app",
+  "crates/xtask",
+  "crates/workspace-tests",
+]
+exclude_paths = [
+  "benchmarks",
+  "fuzz",
+  ".template",
+  "docs/patterns",
+]
+exclude_workflows = [
+  "cleanup-ci-status.yml",
+  "deploy-docs.yml",
+  "dora-fdrt.yml",
+  "dora-report.yml",
+  "eval.yml",
+  "fuzz.yml",
+  "labeler.yml",
+  "mutants.yml",
+  "patch-release-on-label.yml",
+  "skills-evaluation.yml",
+  "sync-labels.yml",
+  "update-architecture-diagram.yml",
+]
+
+[ci]
+default_tier = "pull-request"
+
+[post_init]
+checklist = [
+  "set-package-metadata",
+  "choose-cargo-lock-policy",
+  "configure-license-policy",
+  "configure-branch-protection",
+]

--- a/config/template-profiles/service.toml
+++ b/config/template-profiles/service.toml
@@ -1,0 +1,45 @@
+# Service profile — long-running service with actor and storage patterns.
+[metadata]
+id = "service"
+display_name = "Rust Service"
+description = "Long-running service keeping the actor-runtime and storage/registry patterns."
+
+[workspace]
+include_crates = [
+  "crates/actor-runtime-template",
+  "crates/example-crate",
+  "crates/example-storage-pattern",
+  "crates/hybrid-storage-template",
+  "crates/xtask",
+  "crates/workspace-tests",
+]
+exclude_paths = [
+  "benchmarks",
+  "fuzz",
+  ".template",
+  "docs/patterns",
+]
+exclude_workflows = [
+  "cleanup-ci-status.yml",
+  "deploy-docs.yml",
+  "eval.yml",
+  "fuzz.yml",
+  "labeler.yml",
+  "mutants.yml",
+  "patch-release-on-label.yml",
+  "skills-evaluation.yml",
+  "sync-labels.yml",
+  "update-architecture-diagram.yml",
+]
+
+[ci]
+default_tier = "protected-branch"
+
+[post_init]
+checklist = [
+  "set-package-metadata",
+  "choose-cargo-lock-policy",
+  "configure-license-policy",
+  "configure-branch-protection",
+  "configure-health-check-endpoint",
+]

--- a/config/template-profiles/workspace.toml
+++ b/config/template-profiles/workspace.toml
@@ -1,0 +1,32 @@
+# Workspace profile — keep every reference crate, benchmark, and workflow.
+[metadata]
+id = "workspace"
+display_name = "Multi-Crate Workspace"
+description = "Full reference workspace: every pattern crate, benchmark suite, and workflow."
+
+[workspace]
+include_crates = [
+  "crates/actor-runtime-template",
+  "crates/checkpoint-template",
+  "crates/example-crate",
+  "crates/example-registry-pattern",
+  "crates/example-storage-pattern",
+  "crates/hybrid-storage-template",
+  "crates/mcp-server-template",
+  "crates/sample-app",
+  "crates/workspace-tests",
+  "crates/xtask",
+]
+exclude_paths = []
+exclude_workflows = []
+
+[ci]
+default_tier = "protected-branch"
+
+[post_init]
+checklist = [
+  "set-package-metadata",
+  "choose-cargo-lock-policy",
+  "configure-license-policy",
+  "configure-branch-protection",
+]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true, features = ["derive"] }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+toml = { workspace = true }
 thiserror = { workspace = true }
 regex = "1"
 

--- a/crates/xtask/src/changed_paths.rs
+++ b/crates/xtask/src/changed_paths.rs
@@ -24,6 +24,23 @@ pub struct ChangedPaths {
     pub changed_files: Vec<String>,
 }
 
+/// Extracts the unique top-level crate names (`crates/<name>/…`) that contain changed files,
+/// in first-seen order. Used by CI telemetry to report the affected-package scope.
+#[must_use]
+pub fn affected_crates(changed_files: &[String]) -> Vec<String> {
+    let mut seen = Vec::new();
+    for file in changed_files {
+        if let Some(rest) = file.strip_prefix("crates/") {
+            if let Some(crate_name) = rest.split('/').next() {
+                if !crate_name.is_empty() && !seen.iter().any(|s| s == crate_name) {
+                    seen.push(crate_name.to_string());
+                }
+            }
+        }
+    }
+    seen
+}
+
 impl ChangedPaths {
     /// Classifies a list of file paths.
     pub fn classify<S: AsRef<str>>(files: &[S]) -> Self {
@@ -163,6 +180,17 @@ mod tests {
         assert!(!cp.has_workflow_changes);
         assert!(!cp.has_shell_changes);
         assert!(!cp.has_markdown_changes);
+    }
+
+    #[test]
+    fn test_affected_crates_top_level() {
+        let files = vec![
+            "crates/xtask/src/main.rs".to_string(),
+            "crates/xtask/Cargo.toml".to_string(),
+            "crates/sample-app/src/lib.rs".to_string(),
+            "Cargo.toml".to_string(),
+        ];
+        assert_eq!(affected_crates(&files), vec!["xtask", "sample-app"]);
     }
 
     #[test]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -5,13 +5,16 @@ pub mod config;
 pub mod quality;
 pub mod quality_helpers;
 pub mod reporting;
+pub mod telemetry;
 pub mod template_init;
+pub mod template_profile;
 pub mod toolchain;
 
 use clap::{Parser, Subcommand};
 use config::{XtaskConfig, XtaskError};
 use reporting::{CheckResult, QualityReport};
 use std::path::Path;
+use telemetry::{CiTelemetry, TelemetryConfig, TelemetryScope, TelemetryStage, ToolchainInfo};
 
 #[derive(Parser)]
 #[command(name = "xtask")]
@@ -75,10 +78,10 @@ enum QualitySub {
 
 #[derive(Subcommand)]
 enum TemplateSub {
-    /// Initialize template from profile.
+    /// Initialize template from a profile blueprint (see config/template-profiles/).
     Init {
         #[arg(long)]
-        profile: String, // "minimal" or "full"
+        profile: String, // e.g. "minimal", "library", "cli", "service", "workspace", "ai-agent"
         #[arg(long)]
         name: Option<String>,
         #[arg(long)]
@@ -89,6 +92,18 @@ enum TemplateSub {
         repo: Option<String>,
         #[arg(long)]
         dry_run: bool,
+    },
+    /// Validate a profile blueprint by id or path.
+    ValidateProfile {
+        /// Profile id or path to a .toml blueprint.
+        #[arg(long)]
+        profile: String,
+    },
+    /// Print an inspection summary of a shipped profile.
+    Inspect {
+        /// Shipped profile id, e.g. "minimal".
+        #[arg(long)]
+        profile: String,
     },
 }
 
@@ -105,6 +120,14 @@ fn get_rfc3339_timestamp() -> String {
     )
 }
 
+/// Runs the configured quality gate and emits structured telemetry (issue #289).
+///
+/// Long by design: it orchestrates planning, execution, reporting, and telemetry in one
+/// linear sequence so CI can treat the whole gate as a single stage.
+#[expect(
+    clippy::too_many_lines,
+    reason = "orchestration spans plan/run/report/telemetry; splitting obscures the linear flow"
+)]
 fn handle_quality_run(
     config: &XtaskConfig,
     tier: Option<&str>,
@@ -128,37 +151,97 @@ fn handle_quality_run(
         )?;
     }
 
+    // Full tier plan (for skip-reporting) vs the scoped plan actually run.
+    let full_checks = quality::plan_checks(config, tier, None, None)?;
     let planned_checks = quality::plan_checks(config, tier, only, changed_from)?;
-    println!("Planned checks to execute:");
+    println!(
+        "Planned checks to execute ({} of {}):",
+        planned_checks.len(),
+        full_checks.len()
+    );
     for check in &planned_checks {
         println!("  - {}", check.name());
     }
     println!();
 
     let mut results = Vec::new();
+    let mut stages: Vec<TelemetryStage> = Vec::new();
     let mut overall_success = true;
 
-    for check in planned_checks {
+    for check in &full_checks {
         let name = check.name().to_string();
+        if !planned_checks.contains(check) {
+            let reason = if changed_from.is_some() {
+                "not affected by changed paths"
+            } else {
+                "excluded by --only filter"
+            };
+            stages.push(TelemetryStage {
+                id: telemetry::stage_id(&name),
+                status: "skipped".to_string(),
+                duration_ms: 0,
+                cache: "not-applicable".to_string(),
+                skipped_reason: Some(reason.to_string()),
+            });
+            continue;
+        }
         let start = std::time::Instant::now();
-        match quality::run_check(check, config) {
-            Ok(()) => {
-                results.push(CheckResult {
-                    name,
-                    status: "success".to_string(),
-                    message: Some(format!("Passed in {:?}", start.elapsed())),
-                });
-            }
+        let outcome = match quality::run_check(*check, config) {
+            Ok(()) => "success",
             Err(e) => {
                 overall_success = false;
                 results.push(CheckResult {
-                    name,
+                    name: name.clone(),
                     status: "failed".to_string(),
                     message: Some(e.to_string()),
                 });
+                "failed"
             }
+        };
+        if outcome == "success" {
+            results.push(CheckResult {
+                name: name.clone(),
+                status: "success".to_string(),
+                message: Some(format!("Passed in {:?}", start.elapsed())),
+            });
         }
+        stages.push(TelemetryStage {
+            id: telemetry::stage_id(&name),
+            status: if outcome == "failed" {
+                "failed"
+            } else {
+                "passed"
+            }
+            .to_string(),
+            duration_ms: u64::try_from(start.elapsed().as_millis()).unwrap_or(u64::MAX),
+            cache: "not-applicable".to_string(),
+            skipped_reason: None,
+        });
     }
+
+    // Telemetry scope: affected packages when a base was supplied, else the whole workspace.
+    let (scope_mode, scope_packages, scope_fallback) = changed_from.map_or_else(
+        || ("all", Vec::new(), false),
+        |base| {
+            let affected = crate::changed_paths::ChangedPaths::from_git(base).map_or_else(
+                |_| {
+                    println!("  ! Unable to resolve changed paths; falling back to full scope");
+                    Vec::new()
+                },
+                |cp| crate::changed_paths::affected_crates(&cp.changed_files),
+            );
+            let is_affected = !affected.is_empty();
+            (
+                if is_affected {
+                    "affected-packages"
+                } else {
+                    "all"
+                },
+                affected,
+                !is_affected,
+            )
+        },
+    );
 
     let commit_sha = std::env::var("GITHUB_SHA").unwrap_or_else(|_| {
         commands::execute_captured("git", &["rev-parse", "HEAD"])
@@ -190,6 +273,40 @@ fn handle_quality_run(
     report.write_json_report()?;
     report.write_github_summary()?;
 
+    // Telemetry (issue #289): structured artifact + Markdown summary, always emitted.
+    let telemetry_config = TelemetryConfig::load_or_default();
+    let telemetry = CiTelemetry {
+        schema_version: telemetry::SCHEMA_VERSION,
+        timestamp: get_rfc3339_timestamp(),
+        tier: report_tier(config, tier),
+        plan_source: "config/xtask.json".to_string(),
+        scope: TelemetryScope {
+            mode: scope_mode.to_string(),
+            packages: scope_packages,
+            fallback_used: scope_fallback,
+        },
+        stages,
+        toolchain: ToolchainInfo::capture(),
+    };
+    telemetry.emit(&telemetry_config)?;
+    // Surface the telemetry summary in the GHA step summary too, when present.
+    if let Ok(summary_path) = std::env::var("GITHUB_STEP_SUMMARY") {
+        if !summary_path.is_empty() {
+            use std::io::Write as _;
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&summary_path)
+                .map_err(|e| XtaskError::CacheIssue {
+                    message: e.to_string(),
+                })?;
+            writeln!(file, "\n{}", telemetry.summary_markdown(&telemetry_config)).map_err(|e| {
+                XtaskError::CacheIssue {
+                    message: e.to_string(),
+                }
+            })?;
+        }
+    }
+
     if overall_success {
         Ok(())
     } else {
@@ -197,6 +314,16 @@ fn handle_quality_run(
             command: "quality run".to_string(),
             exit_code: Some(1),
         })
+    }
+}
+
+fn report_tier(config: &XtaskConfig, tier: Option<&str>) -> String {
+    let env = std::env::var(&config.env_var_name).ok();
+    let sel = tier.or(env.as_deref()).unwrap_or(&config.default_tier);
+    match sel {
+        "fast-pr" => "pull-request".to_string(),
+        "full-gate" | "all" => "protected-branch".to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -281,6 +408,16 @@ fn main() {
                 repo.as_deref(),
                 dry_run,
             ),
+            TemplateSub::ValidateProfile { profile } => {
+                template_profile::TemplateProfile::load_from_path(&profile)
+                    .or_else(|_| template_profile::TemplateProfile::load(&profile))
+                    .map(|loaded| {
+                        println!("  ✓ Profile '{}' is valid", loaded.metadata.id);
+                    })
+            }
+            TemplateSub::Inspect { profile } => {
+                template_profile::TemplateProfile::load(&profile).map(|loaded| loaded.inspect())
+            }
         },
         Cmd::Report { sub } => match sub {
             ReportSub::GithubSummary => handle_github_summary(),

--- a/crates/xtask/src/telemetry.rs
+++ b/crates/xtask/src/telemetry.rs
@@ -1,0 +1,400 @@
+//! Structured CI telemetry: emits `quality-run.json` and `quality-summary.md`.
+//!
+//! This is the portable, SaaS-free observability contract for the quality gate
+//! (issue #289). Every `xtask quality run` writes a schema-versioned JSON artifact
+//! plus a human-readable Markdown summary, so CI runs are debuggable without an
+//! external monitoring stack.
+
+use crate::commands;
+use crate::config::XtaskError;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Write as _;
+use std::path::Path;
+
+/// Current telemetry artifact schema version (bump on any breaking field change).
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Configurable telemetry behaviour (budgets are configuration, not application logic).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TelemetryConfig {
+    /// Master switch for emitting the telemetry artifact and summary.
+    pub enabled: bool,
+    /// Detail level: "minimal" or "full". "minimal" omits the per-stage cache/scope detail.
+    pub detail: String,
+    /// Days an emitted artifact should be retained by CI.
+    pub retention_days: u32,
+    /// Relative path of the Markdown summary.
+    pub summary_path: String,
+    /// Relative path of the JSON artifact.
+    pub artifact_path: String,
+    /// Execution budgets used to surface slow stages.
+    pub budgets: TelemetryBudgets,
+}
+
+/// Stage-duration budgets surfaced in the summary when exceeded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TelemetryBudgets {
+    /// Per-stage wall-clock budget in milliseconds.
+    pub max_stage_duration_ms: u64,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            detail: "full".to_string(),
+            retention_days: 7,
+            summary_path: ".agents/ci/quality-summary.md".to_string(),
+            artifact_path: ".agents/ci/quality-run.json".to_string(),
+            budgets: TelemetryBudgets {
+                max_stage_duration_ms: 600_000,
+            },
+        }
+    }
+}
+
+impl TelemetryConfig {
+    /// Loads `config/ci/telemetry.toml`, falling back to defaults when absent or broken.
+    #[must_use]
+    pub fn load_or_default() -> Self {
+        fn default_with_warning(reason: &dyn std::fmt::Display) -> TelemetryConfig {
+            println!("  ! Warning: config/ci/telemetry.toml invalid ({reason}); using defaults");
+            TelemetryConfig::default()
+        }
+        fs::read_to_string("config/ci/telemetry.toml").map_or_else(
+            |_| Self::default(),
+            |content| toml::from_str(&content).unwrap_or_else(|e| default_with_warning(&e)),
+        )
+    }
+}
+
+/// Decides which packages are in scope for the current run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TelemetryScope {
+    /// "affected-packages" when a `--changed-from` base was supplied, else "all".
+    pub mode: String,
+    /// Unique crate names affected (top-level `crates/<name>/`), empty for "all".
+    pub packages: Vec<String>,
+    /// Whether the scope fell back to "all" (e.g. unresolved base or plan failure).
+    pub fallback_used: bool,
+}
+
+/// Outcome of a single quality stage.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TelemetryStage {
+    /// Stage id (kebab-case check name).
+    pub id: String,
+    /// "passed", "failed", or "skipped".
+    pub status: String,
+    /// Wall-clock duration in milliseconds.
+    pub duration_ms: u64,
+    /// Cache state for this stage: "restored", "saved", "miss", or "not-applicable".
+    pub cache: String,
+    /// Why the stage was skipped, when skipped.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skipped_reason: Option<String>,
+}
+
+/// Toolchain versions captured at run time.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolchainInfo {
+    /// `rustc --version` output.
+    pub rustc: String,
+    /// `cargo --version` output.
+    pub cargo: String,
+    /// `cargo nextest --version` output (or "unavailable" when only standard cargo test exists).
+    pub nextest: String,
+}
+
+/// The full telemetry artifact emitted after a quality run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CiTelemetry {
+    /// Artifact schema version (see [`SCHEMA_VERSION`]).
+    pub schema_version: u32,
+    /// ISO-8601 UTC timestamp of the run.
+    pub timestamp: String,
+    /// Selected tier (canonical name), e.g. "pull-request".
+    pub tier: String,
+    /// Where the tier plan came from, e.g. "config/xtask.json".
+    pub plan_source: String,
+    /// Changed-package scope decision for this run.
+    pub scope: TelemetryScope,
+    /// Executed and skipped stages with timing.
+    pub stages: Vec<TelemetryStage>,
+    /// Toolchain versions at run time.
+    pub toolchain: ToolchainInfo,
+}
+
+/// Converts a human check name ("Rust Format") into a kebab-case stage id ("rust-format").
+#[must_use]
+pub fn stage_id(name: &str) -> String {
+    name.to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+impl ToolchainInfo {
+    /// Captures current tool versions; missing tools are reported as "unavailable".
+    #[must_use]
+    pub fn capture() -> Self {
+        fn first_line(cmd: &str, args: &[&str]) -> String {
+            commands::execute_captured(cmd, args).map_or_else(
+                |_| format!("{cmd}: unavailable"),
+                |out| {
+                    out.lines()
+                        .next()
+                        .unwrap_or("unavailable")
+                        .trim()
+                        .to_string()
+                },
+            )
+        }
+        Self {
+            rustc: first_line("rustc", &["--version"]),
+            cargo: first_line("cargo", &["--version"]),
+            nextest: first_line("cargo", &["nextest", "--version"]),
+        }
+    }
+}
+
+impl CiTelemetry {
+    /// Writes the JSON artifact and the Markdown summary next to it.
+    ///
+    /// # Errors
+    /// Returns `XtaskError::CacheIssue` if an artifact cannot be written.
+    pub fn emit(&self, config: &TelemetryConfig) -> Result<(), XtaskError> {
+        if !config.enabled {
+            println!("  ! Telemetry disabled via config/ci/telemetry.toml");
+            return Ok(());
+        }
+
+        // JSON artifact.
+        let artifact = Path::new(&config.artifact_path);
+        if let Some(parent) = artifact.parent() {
+            fs::create_dir_all(parent).map_err(|e| XtaskError::CacheIssue {
+                message: format!("Failed to create {}: {e}", parent.display()),
+            })?;
+        }
+        let json = serde_json::to_string_pretty(self).map_err(|e| XtaskError::InvalidConfig {
+            message: e.to_string(),
+        })?;
+        let mut file = fs::File::create(artifact).map_err(|e| XtaskError::CacheIssue {
+            message: e.to_string(),
+        })?;
+        file.write_all(json.as_bytes())
+            .map_err(|e| XtaskError::CacheIssue {
+                message: e.to_string(),
+            })?;
+        println!("  ✓ Wrote telemetry artifact to {}", artifact.display());
+
+        // Markdown summary.
+        let summary = Path::new(&config.summary_path);
+        if let Some(parent) = summary.parent() {
+            fs::create_dir_all(parent).map_err(|e| XtaskError::CacheIssue {
+                message: format!("Failed to create {}: {e}", parent.display()),
+            })?;
+        }
+        let mut file = fs::File::create(summary).map_err(|e| XtaskError::CacheIssue {
+            message: e.to_string(),
+        })?;
+        file.write_all(self.summary_markdown(config).as_bytes())
+            .map_err(|e| XtaskError::CacheIssue {
+                message: e.to_string(),
+            })?;
+        println!("  ✓ Wrote telemetry summary to {}", summary.display());
+        Ok(())
+    }
+
+    /// Renders the human-readable summary (also appended to the GHA step summary by CI).
+    #[must_use]
+    pub fn summary_markdown(&self, config: &TelemetryConfig) -> String {
+        use std::fmt::Write as _;
+        let mut md = String::new();
+        let _ = writeln!(
+            md,
+            "## Quality Run Telemetry (schema v{})",
+            self.schema_version
+        );
+        let _ = writeln!(md, "- **Tier:** {}", self.tier);
+        let _ = writeln!(md, "- **Plan source:** {}", self.plan_source);
+        let _ = writeln!(md, "- **Scope:** {} {}", self.scope.mode, {
+            if self.scope.packages.is_empty() {
+                "(whole workspace)".to_string()
+            } else {
+                format!("({})", self.scope.packages.join(", "))
+            }
+        });
+        if self.scope.fallback_used {
+            let _ = writeln!(md, "- **Scope fallback:** used (base/plan unavailable)");
+        }
+        let _ = writeln!(md);
+        let _ = writeln!(md, "| Stage | Status | Duration | Cache | Reason |");
+        let _ = writeln!(md, "|---|---|---|---|---|");
+        for stage in &self.stages {
+            let emoji = match stage.status.as_str() {
+                "passed" => "✅ passed",
+                "failed" => "❌ failed",
+                _ => "⏭️ skipped",
+            };
+            let reason = stage.skipped_reason.as_deref().unwrap_or("");
+            let _ = writeln!(
+                md,
+                "| {} | {emoji} | {} ms | {} | {reason} |",
+                stage.id, stage.duration_ms, stage.cache
+            );
+        }
+        let _ = writeln!(
+            md,
+            "- **Toolchain:** rustc={}, cargo={}, nextest={}",
+            self.toolchain.rustc, self.toolchain.cargo, self.toolchain.nextest
+        );
+        if config.detail != "minimal" {
+            let over = self
+                .stages
+                .iter()
+                .filter(|s| s.duration_ms > config.budgets.max_stage_duration_ms)
+                .map(|s| s.id.as_str())
+                .collect::<Vec<_>>();
+            if !over.is_empty() {
+                let _ = writeln!(
+                    md,
+                    "- ⚠️ **Budget exceeded** (>{} ms): {}",
+                    config.budgets.max_stage_duration_ms,
+                    over.join(", ")
+                );
+            }
+        }
+        md
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use std::path::PathBuf;
+
+    fn sample_telemetry() -> CiTelemetry {
+        CiTelemetry {
+            schema_version: SCHEMA_VERSION,
+            timestamp: "2026-08-09T00:00:00Z".to_string(),
+            tier: "pull-request".to_string(),
+            plan_source: "config/xtask.json".to_string(),
+            scope: TelemetryScope {
+                mode: "affected-packages".to_string(),
+                packages: vec!["xtask".to_string()],
+                fallback_used: false,
+            },
+            stages: vec![
+                TelemetryStage {
+                    id: "rust-format".to_string(),
+                    status: "passed".to_string(),
+                    duration_ms: 12,
+                    cache: "not-applicable".to_string(),
+                    skipped_reason: None,
+                },
+                TelemetryStage {
+                    id: "rust-tests".to_string(),
+                    status: "skipped".to_string(),
+                    duration_ms: 0,
+                    cache: "not-applicable".to_string(),
+                    skipped_reason: Some("not affected by changed paths".to_string()),
+                },
+            ],
+            toolchain: ToolchainInfo {
+                rustc: "rustc 1.88.0".to_string(),
+                cargo: "cargo 1.88.0".to_string(),
+                nextest: "cargo-nextest 0.9".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn test_serializes_with_schema_version() {
+        let json = serde_json::to_value(sample_telemetry()).unwrap();
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["scope"]["mode"], "affected-packages");
+        assert_eq!(json["stages"][1]["status"], "skipped");
+        // No secrets/source fields are emitted by the struct.
+        let keys: Vec<&str> = json
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert!(
+            !keys
+                .iter()
+                .any(|k| k.to_lowercase().contains("token") || k.to_lowercase().contains("secret"))
+        );
+    }
+
+    #[test]
+    fn test_emit_writes_artifact_and_summary() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = TelemetryConfig {
+            enabled: true,
+            detail: "full".to_string(),
+            retention_days: 7,
+            summary_path: dir
+                .path()
+                .join("quality-summary.md")
+                .to_string_lossy()
+                .into_owned(),
+            artifact_path: dir
+                .path()
+                .join("quality-run.json")
+                .to_string_lossy()
+                .into_owned(),
+            budgets: TelemetryBudgets {
+                max_stage_duration_ms: 600_000,
+            },
+        };
+        sample_telemetry().emit(&config).unwrap();
+        let artifact: CiTelemetry =
+            serde_json::from_str(&std::fs::read_to_string(&config.artifact_path).unwrap()).unwrap();
+        assert_eq!(artifact.schema_version, SCHEMA_VERSION);
+        assert_eq!(artifact.stages.len(), 2);
+        let summary = std::fs::read_to_string(&config.summary_path).unwrap();
+        assert!(summary.contains("pull-request"));
+        assert!(summary.contains("rust-format"));
+    }
+
+    #[test]
+    fn test_config_load_disabled_skips_emit() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = TelemetryConfig {
+            enabled: false,
+            detail: "full".to_string(),
+            retention_days: 7,
+            summary_path: dir.path().join("s.md").to_string_lossy().into_owned(),
+            artifact_path: dir.path().join("a.json").to_string_lossy().into_owned(),
+            budgets: TelemetryBudgets {
+                max_stage_duration_ms: 600_000,
+            },
+        };
+        sample_telemetry().emit(&config).unwrap();
+        assert!(!PathBuf::from(&config.artifact_path).exists());
+    }
+
+    #[test]
+    fn test_summary_marks_budget_exceeded() {
+        let mut t = sample_telemetry();
+        t.stages[0].duration_ms = 999_999;
+        let md = t.summary_markdown(&TelemetryConfig::default());
+        assert!(md.contains("Budget exceeded"));
+        assert!(md.contains("rust-format"));
+    }
+
+    #[test]
+    fn test_stage_id_kebab() {
+        assert_eq!(stage_id("Rust Format"), "rust-format");
+        assert_eq!(
+            stage_id("CI Status Artifact Check"),
+            "ci-status-artifact-check"
+        );
+    }
+}

--- a/crates/xtask/src/template_init.rs
+++ b/crates/xtask/src/template_init.rs
@@ -1,13 +1,19 @@
-//! Template initialization logic.
+//! Template initialization logic (profile-driven, issue #286).
+//!
+//! A `cargo xtask template init --profile <id>` loads the matching blueprint from
+//! `config/template-profiles/`, validates it, shapes the workspace (remove unselected
+//! crates, paths, workflows), renames the example crate, applies placeholder
+//! replacements, writes the profile's CI-tier default, and prints the post-init checklist.
 
 use crate::config::XtaskError;
-use std::fs::{read_to_string, remove_dir_all, remove_file, write};
+use crate::template_profile::TemplateProfile;
+use std::fs::{read_dir, read_to_string, remove_dir_all, remove_file, write};
 use std::path::Path;
 
-/// Run the template initialization.
+/// Run the template initialization using a validated profile blueprint.
 ///
 /// # Errors
-/// Returns `XtaskError` if reading/writing/deleting files or folders fails.
+/// Returns `XtaskError` if the profile is unknown/invalid or any file operation fails.
 pub fn run_init(
     profile: &str,
     name: Option<&str>,
@@ -16,7 +22,11 @@ pub fn run_init(
     repo: Option<&str>,
     dry_run: bool,
 ) -> Result<(), XtaskError> {
-    println!("==> Initializing template with profile: {profile}");
+    let blueprint = TemplateProfile::load(profile)?;
+    println!(
+        "==> Initializing template with profile: {}",
+        blueprint.metadata.id
+    );
 
     let proj_name = name.unwrap_or("my-app");
     let proj_desc = description.unwrap_or("A production-ready Rust workspace");
@@ -25,90 +35,161 @@ pub fn run_init(
 
     if dry_run {
         println!("  [DRY RUN] Would initialize project '{proj_name}' ({proj_desc})");
+        let existing = existing_crates()?;
+        let removed = blueprint.removed_crates(&existing);
+        println!(
+            "  [DRY RUN] Would remove {} crate(s): {removed:?}",
+            removed.len()
+        );
+        for p in &blueprint.workspace.exclude_paths {
+            println!("  [DRY RUN] Would remove path: {p}");
+        }
+        for wf in &blueprint.workspace.exclude_workflows {
+            println!("  [DRY RUN] Would remove workflow: .github/workflows/{wf}");
+        }
+        println!(
+            "  [DRY RUN] Would set default CI tier: {}",
+            blueprint.ci.default_tier
+        );
         return Ok(());
     }
 
-    if profile == "minimal" {
-        apply_minimal_profile()?;
-    }
-
+    apply_profile(&blueprint)?;
     rename_example_crate(proj_name)?;
     perform_replacements(proj_name, proj_author, proj_repo)?;
+    apply_ci_tier(&blueprint)?;
+    print_post_init(&blueprint);
 
-    println!("  ✓ Template initialized successfully!");
+    println!(
+        "  ✓ Template initialized successfully with profile '{}'!",
+        blueprint.metadata.id
+    );
     Ok(())
 }
 
-fn apply_minimal_profile() -> Result<(), XtaskError> {
-    println!("  -> Applying minimal profile...");
-    let optional_crates = &[
-        "actor-runtime-template",
-        "checkpoint-template",
-        "hybrid-storage-template",
-        "mcp-server-template",
-        "example-registry-pattern",
-        "example-storage-pattern",
-    ];
-    for crate_name in optional_crates {
-        let path = format!("crates/{crate_name}");
-        let p = Path::new(&path);
-        if p.exists() {
-            remove_dir_all(p).map_err(|e| XtaskError::CacheIssue {
+/// Applies the profile's workspace-shaping decisions (removals only; no generation).
+fn apply_profile(blueprint: &TemplateProfile) -> Result<(), XtaskError> {
+    println!("  -> Applying '{}' profile...", blueprint.metadata.id);
+
+    let existing = existing_crates()?;
+    for removed in blueprint.removed_crates(&existing) {
+        let path = format!("crates/{removed}");
+        if Path::new(&path).exists() {
+            remove_dir_all(&path).map_err(|e| XtaskError::CacheIssue {
                 message: e.to_string(),
             })?;
             println!("     Removed {path}");
         }
     }
 
-    let optional_workflows = &[
-        "dora-fdrt.yml",
-        "dora-report.yml",
-        "eval.yml",
-        "mutants.yml",
-        "skills-evaluation.yml",
-        "update-architecture-diagram.yml",
-        "cleanup-ci-status.yml",
-        "sync-labels.yml",
-        "labeler.yml",
-        "patch-release-on-label.yml",
-        "deploy-docs.yml",
-        "fuzz.yml",
-    ];
-    for wf in optional_workflows {
+    for excluded in &blueprint.workspace.exclude_paths {
+        remove_path(excluded)?;
+    }
+
+    for wf in &blueprint.workspace.exclude_workflows {
         let path = format!(".github/workflows/{wf}");
-        let p = Path::new(&path);
-        if p.exists() {
-            remove_file(p).map_err(|e| XtaskError::CacheIssue {
+        remove_path(&path)?;
+    }
+
+    // Drop `benchmarks` from workspace members when the profile excludes it.
+    if blueprint
+        .workspace
+        .exclude_paths
+        .iter()
+        .any(|p| p == "benchmarks")
+    {
+        let cargo_toml_path = Path::new("Cargo.toml");
+        if cargo_toml_path.exists() {
+            let mut content =
+                read_to_string(cargo_toml_path).map_err(|e| XtaskError::CacheIssue {
+                    message: e.to_string(),
+                })?;
+            content = content.replace(", \"benchmarks\"", "");
+            content = content.replace("\"benchmarks\", ", "");
+            write(cargo_toml_path, content).map_err(|e| XtaskError::CacheIssue {
                 message: e.to_string(),
             })?;
-            println!("     Removed {path}");
+            println!("     Adjusted Cargo.toml workspace members");
         }
     }
 
-    let optional_dirs = &["fuzz", "benchmarks", "docs/patterns", ".template"];
-    for dir in optional_dirs {
-        let p = Path::new(dir);
-        if p.exists() {
-            remove_dir_all(p).map_err(|e| XtaskError::CacheIssue {
-                message: e.to_string(),
-            })?;
-            println!("     Removed {dir}");
+    Ok(())
+}
+
+/// Writes the profile's `ci.default_tier` into `config/xtask.json`.
+fn apply_ci_tier(blueprint: &TemplateProfile) -> Result<(), XtaskError> {
+    let path = Path::new("config/xtask.json");
+    if !path.exists() {
+        println!(
+            "     ! config/xtask.json not found; skipping CI tier default (profile: {})",
+            blueprint.ci.default_tier
+        );
+        return Ok(());
+    }
+    let content = read_to_string(path).map_err(|e| XtaskError::CacheIssue {
+        message: e.to_string(),
+    })?;
+    let mut value: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| XtaskError::InvalidConfig {
+            message: e.to_string(),
+        })?;
+    value["default_tier"] = serde_json::Value::String(blueprint.ci.default_tier.clone());
+    let updated = serde_json::to_string_pretty(&value).map_err(|e| XtaskError::InvalidConfig {
+        message: e.to_string(),
+    })?;
+    write(path, updated).map_err(|e| XtaskError::CacheIssue {
+        message: e.to_string(),
+    })?;
+    println!(
+        "     Set config/xtask.json default tier: {}",
+        blueprint.ci.default_tier
+    );
+    Ok(())
+}
+
+/// Prints the profile's post-init checklist (items that cannot travel through a GitHub template).
+fn print_post_init(blueprint: &TemplateProfile) {
+    if blueprint.post_init.checklist.is_empty() {
+        return;
+    }
+    println!();
+    println!("  ── Post-init checklist ──");
+    for item in &blueprint.post_init.checklist {
+        println!("     - [ ] {item}");
+    }
+}
+
+/// Lists top-level crate directory names under `crates/`.
+fn existing_crates() -> Result<Vec<String>, XtaskError> {
+    let mut names = Vec::new();
+    let entries = read_dir("crates").map_err(|e| XtaskError::CacheIssue {
+        message: e.to_string(),
+    })?;
+    for entry in entries.flatten() {
+        if entry.path().is_dir() {
+            if let Some(name) = entry.file_name().to_str() {
+                names.push(name.to_string());
+            }
         }
     }
+    names.sort_unstable();
+    Ok(names)
+}
 
-    let cargo_toml_path = Path::new("Cargo.toml");
-    if cargo_toml_path.exists() {
-        let mut content = read_to_string(cargo_toml_path).map_err(|e| XtaskError::CacheIssue {
+/// Removes a path whether it is a file, directory, or already absent (idempotent).
+fn remove_path(p: &str) -> Result<(), XtaskError> {
+    let path = Path::new(p);
+    if path.is_dir() {
+        remove_dir_all(path).map_err(|e| XtaskError::CacheIssue {
             message: e.to_string(),
         })?;
-        content = content.replace(", \"benchmarks\"", "");
-        content = content.replace("\"benchmarks\", ", "");
-        write(cargo_toml_path, content).map_err(|e| XtaskError::CacheIssue {
+        println!("     Removed {p}");
+    } else if path.is_file() {
+        remove_file(path).map_err(|e| XtaskError::CacheIssue {
             message: e.to_string(),
         })?;
-        println!("     Adjusted Cargo.toml workspace members");
+        println!("     Removed {p}");
     }
-
     Ok(())
 }
 
@@ -131,6 +212,7 @@ fn perform_replacements(
     proj_repo: &str,
 ) -> Result<(), XtaskError> {
     println!("  -> Performing string replacements...");
+    let proj_snake = proj_name.replace('-', "_");
     replace_placeholder("Cargo.toml", "Your Name", proj_author)?;
     replace_placeholder("Cargo.toml", "your-org/your-repo", proj_repo)?;
     replace_placeholder(
@@ -148,14 +230,45 @@ fn perform_replacements(
 
     let example_readme = format!("crates/{proj_name}/README.md");
     replace_placeholder(&example_readme, "example-crate", proj_name)?;
+    replace_placeholder(&example_readme, "example_crate", &proj_snake)?;
 
     replace_placeholder("AGENTS.md", "rust-2026-template", proj_name)?;
-    replace_placeholder("README.md", "rust-2026-template", proj_name)?;
     replace_placeholder(
         "README.md",
         "https://github.com/d-oit/rust-2026-template",
         &format!("https://github.com/{proj_repo}"),
     )?;
+
+    // Tool-adapter and contribution docs carry the template name — rename them too so a
+    // generated project has no stale references.
+    for doc in [
+        "CLAUDE.md",
+        "GEMINI.md",
+        "QWEN.md",
+        "CONTRIBUTING.md",
+        "SECURITY.md",
+        "QUICKSTART.md",
+    ] {
+        replace_placeholder(doc, "rust-2026-template", proj_name)?;
+    }
+
+    // Examples/benchmarks that reference the renamed example crate keep the workspace buildable.
+    replace_placeholder(
+        "examples/hello_world/Cargo.toml",
+        "example-crate",
+        proj_name,
+    )?;
+    replace_placeholder(
+        "examples/hello_world/src/main.rs",
+        "example-crate",
+        proj_name,
+    )?;
+    replace_placeholder(
+        "examples/hello_world/src/main.rs",
+        "example_crate",
+        &proj_snake,
+    )?;
+    replace_placeholder("benchmarks/Cargo.toml", "example-crate", proj_name)?;
 
     Ok(())
 }

--- a/crates/xtask/src/template_profile.rs
+++ b/crates/xtask/src/template_profile.rs
@@ -1,0 +1,304 @@
+//! Validated project blueprints (issue #286).
+//!
+//! A `TemplateProfile` is a declarative TOML blueprint that decides which crates,
+//! directories, workflows, CI tier, and post-init checklist a generated project keeps.
+//! Profiles live in `config/template-profiles/` and are validated before use.
+
+use crate::config::XtaskError;
+use serde::Deserialize;
+use std::fs;
+use std::path::Path;
+
+/// Directory holding the shipped profile blueprints, relative to the repository root.
+pub const PROFILES_DIR: &str = "config/template-profiles";
+
+/// The ids of the shipped profiles, in display order.
+pub const SHIPPED_PROFILES: &[&str] = &[
+    "minimal",
+    "library",
+    "cli",
+    "service",
+    "workspace",
+    "ai-agent",
+];
+
+/// Profile metadata.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileMetadata {
+    /// Machine id (`^[a-z][a-z0-9-]*$`), e.g. "library". Used as `--profile <id>`.
+    pub id: String,
+    /// Human title, e.g. "Rust Library".
+    pub display_name: String,
+    /// One-line description.
+    pub description: String,
+}
+
+/// Workspace-shaping decisions.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileWorkspace {
+    /// Crates under `crates/` to KEEP (any other crate is removed).
+    pub include_crates: Vec<String>,
+    /// Non-crate paths to remove (`benchmarks`, `fuzz`, `.template`, …).
+    #[serde(default)]
+    pub exclude_paths: Vec<String>,
+    /// Workflow files under `.github/workflows/` to remove.
+    #[serde(default)]
+    pub exclude_workflows: Vec<String>,
+}
+
+/// CI defaults applied by this profile.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProfileCi {
+    /// Default verification tier to write into `config/xtask.json`.
+    pub default_tier: String,
+}
+
+/// Post-init guidance that cannot travel through a GitHub template.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PostInit {
+    /// Ordered checklist items for the generated project's README/ADR.
+    pub checklist: Vec<String>,
+}
+
+/// A validated profile blueprint.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TemplateProfile {
+    /// Profile metadata.
+    pub metadata: ProfileMetadata,
+    /// Workspace-shaping decisions.
+    pub workspace: ProfileWorkspace,
+    /// CI defaults.
+    pub ci: ProfileCi,
+    /// Post-init checklist.
+    pub post_init: PostInit,
+}
+
+impl TemplateProfile {
+    /// Parses and structurally validates profile TOML.
+    ///
+    /// # Errors
+    /// Returns `XtaskError::InvalidConfig` when the TOML is malformed or violates the schema.
+    pub fn from_toml(content: &str) -> Result<Self, XtaskError> {
+        let profile: Self = toml::from_str(content).map_err(|e| XtaskError::InvalidConfig {
+            message: format!("Invalid profile TOML: {e}"),
+        })?;
+        profile.validate()
+    }
+
+    /// Loads a profile by id from `PROFILES_DIR`.
+    ///
+    /// # Errors
+    /// Returns `XtaskError::InvalidConfig` when the profile is unknown or invalid.
+    pub fn load(id: &str) -> Result<Self, XtaskError> {
+        let path = format!("{PROFILES_DIR}/{id}.toml");
+        Self::load_from_path(&path).map_err(|e| XtaskError::InvalidConfig {
+            message: format!("Unknown profile '{id}' (expected one of {SHIPPED_PROFILES:?}): {e}"),
+        })
+    }
+
+    /// Loads a profile from an explicit path (used by `validate-profile`).
+    ///
+    /// # Errors
+    /// Returns `XtaskError::InvalidConfig` when the file is missing or invalid.
+    pub fn load_from_path(path: &str) -> Result<Self, XtaskError> {
+        let content = fs::read_to_string(path).map_err(|e| XtaskError::InvalidConfig {
+            message: format!("Failed to read profile '{path}': {e}"),
+        })?;
+        Self::from_toml(&content)
+    }
+
+    /// Validates the profile against the structural rules of `schema/template-profile.schema.json`.
+    ///
+    /// # Errors
+    /// Returns `XtaskError::InvalidConfig` on the first violated rule.
+    pub fn validate(&self) -> Result<Self, XtaskError> {
+        if self.metadata.id.is_empty()
+            || !self
+                .metadata
+                .id
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return Err(self.invalid("metadata.id must be `^[a-z][a-z0-9-]*$`"));
+        }
+        if self.metadata.display_name.trim().is_empty() {
+            return Err(self.invalid("metadata.display_name must not be empty"));
+        }
+        if self.workspace.include_crates.is_empty() {
+            return Err(self.invalid("workspace.include_crates must contain at least one crate"));
+        }
+        for include in &self.workspace.include_crates {
+            if !include.starts_with("crates/") {
+                return Err(self.invalid(&format!(
+                    "workspace.include_crates entry must start with 'crates/', got '{include}'"
+                )));
+            }
+        }
+        if self.ci.default_tier.trim().is_empty() {
+            return Err(self.invalid("ci.default_tier must not be empty"));
+        }
+        Ok(self.clone())
+    }
+
+    /// Computes the crates under `crates/` that this profile removes (those not included).
+    #[must_use]
+    pub fn removed_crates(&self, existing_crates: &[String]) -> Vec<String> {
+        existing_crates
+            .iter()
+            .filter(|crate_name| {
+                let include_path = format!("crates/{crate_name}");
+                !self
+                    .workspace
+                    .include_crates
+                    .iter()
+                    .any(|i| i == &include_path)
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Prints a structured inspection summary.
+    pub fn inspect(&self) {
+        println!(
+            "Profile: {} ({})",
+            self.metadata.id, self.metadata.display_name
+        );
+        println!("  {}", self.metadata.description);
+        println!("Workspace includes:");
+        for crate_path in &self.workspace.include_crates {
+            println!("  - {crate_path}");
+        }
+        if !self.workspace.exclude_paths.is_empty() {
+            println!("Excludes paths:");
+            for p in &self.workspace.exclude_paths {
+                println!("  - {p}");
+            }
+        }
+        if !self.workspace.exclude_workflows.is_empty() {
+            println!("Excludes workflows:");
+            for wf in &self.workspace.exclude_workflows {
+                println!("  - {wf}");
+            }
+        }
+        println!("CI default tier: {}", self.ci.default_tier);
+        println!("Post-init checklist:");
+        for item in &self.post_init.checklist {
+            println!("  - [ ] {item}");
+        }
+    }
+
+    fn invalid(&self, message: &str) -> XtaskError {
+        XtaskError::InvalidConfig {
+            message: format!("Profile '{}' invalid: {message}", self.metadata.id),
+        }
+    }
+}
+
+/// Lists supplied profiles known to exist on disk (for docs/tests).
+#[must_use]
+pub fn shipped_profile_paths(root: &Path) -> Vec<std::path::PathBuf> {
+    SHIPPED_PROFILES
+        .iter()
+        .map(|id| root.join(format!("{PROFILES_DIR}/{id}.toml")))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+    use super::*;
+    use std::path::PathBuf;
+
+    fn repo_root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+    }
+
+    fn profile_path(id: &str) -> String {
+        repo_root()
+            .join(format!("{PROFILES_DIR}/{id}.toml"))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn test_all_shipped_profiles_parse_and_validate() {
+        for id in SHIPPED_PROFILES {
+            let profile = TemplateProfile::load_from_path(&profile_path(id))
+                .unwrap_or_else(|e| panic!("profile {id} must load: {e}"));
+            assert_eq!(profile.metadata.id, *id);
+            assert!(!profile.workspace.include_crates.is_empty());
+            assert!(!profile.ci.default_tier.is_empty());
+            assert!(!profile.post_init.checklist.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_unknown_profile_errors() {
+        let err = TemplateProfile::load("no-such-profile").unwrap_err();
+        assert!(err.to_string().contains("Unknown profile"));
+    }
+
+    #[test]
+    fn test_validate_rejects_empty_include_crates() {
+        let toml = r#"
+[metadata]
+id = "broken"
+display_name = "Broken"
+description = "no includes"
+[workspace]
+include_crates = []
+[ci]
+default_tier = "pull-request"
+[post_init]
+checklist = ["x"]
+"#;
+        let err = TemplateProfile::from_toml(toml).unwrap_err();
+        assert!(err.to_string().contains("include_crates"));
+    }
+
+    #[test]
+    fn test_validate_rejects_unknown_field() {
+        let toml = r#"
+[metadata]
+id = "broken"
+display_name = "Broken"
+description = "extra field"
+[workspace]
+include_crates = ["crates/xtask"]
+stray = true
+[ci]
+default_tier = "pull-request"
+[post_init]
+checklist = ["x"]
+"#;
+        assert!(TemplateProfile::from_toml(toml).is_err());
+    }
+
+    #[test]
+    fn test_removed_crates_plans() {
+        let toml = r#"
+[metadata]
+id = "t"
+display_name = "T"
+description = "d"
+[workspace]
+include_crates = ["crates/xtask"]
+exclude_paths = ["benchmarks"]
+exclude_workflows = ["fuzz.yml"]
+[ci]
+default_tier = "pull-request"
+[post_init]
+checklist = ["x"]
+"#;
+        let profile = TemplateProfile::from_toml(toml).unwrap();
+        let existing = vec!["xtask".to_string(), "sample-app".to_string()];
+        assert_eq!(profile.removed_crates(&existing), vec!["sample-app"]);
+        assert_eq!(profile.workspace.exclude_paths, vec!["benchmarks"]);
+        assert_eq!(profile.workspace.exclude_workflows, vec!["fuzz.yml"]);
+    }
+}

--- a/docs/ci-observability.md
+++ b/docs/ci-observability.md
@@ -1,0 +1,34 @@
+# CI Observability (issue #289)
+
+Every `xtask quality run` (which is what the CI `quality-gate` job invokes) emits
+a structured telemetry artifact and a readable summary — no external SaaS required.
+
+## Artifact
+
+`.agents/ci/quality-run.json` (schema `schema/ci-telemetry.schema.json`, `schema_version: 1`):
+
+- `tier` — which verification tier ran (e.g. `pull-request`, `protected-branch`).
+- `plan_source` — where the check plan came from (`config/xtask.json`).
+- `scope` — `affected-packages` (plus the crate list) when a `--changed-from` base was
+  supplied, otherwise `all`; `fallback_used` is set when the base could not be resolved.
+- `stages` — every configured check with `passed`/`failed`/`skipped`, wall-clock
+  `duration_ms`, cache state, and an explicit `skipped_reason`.
+- `toolchain` — `rustc`/`cargo`/`cargo-nextest` versions captured at run time.
+
+The matching `.agents/ci/quality-summary.md` is the human-readable rendition and is also
+appended to the GitHub Actions step summary. CI uploads `quality-run.json` as the
+`ci-telemetry` artifact (retained per `config/ci/telemetry.toml`).
+
+## Guarantees
+
+- **Always emitted**: telemetry is written even when a stage fails (the gate reports the
+  overall failure *after* emitting).
+- **No secrets**: the schema contains no source content, tokens, env dumps, or credentials.
+- **Configurable**: budgets and behaviour live in `config/ci/telemetry.toml`
+  (`enabled`, `detail`, `retention_days`, `max_stage_duration_ms`), never in xtask logic.
+- **Portable**: downstream repos can export `quality-run.json` to their own observability
+  stack, or disable telemetry entirely.
+
+## Budgets
+
+Stages that exceed `budgets.max_stage_duration_ms` are flagged in the summary.

--- a/docs/template-profiles.md
+++ b/docs/template-profiles.md
@@ -1,0 +1,54 @@
+# Project Profiles (issue #286)
+
+Profiles are **validated blueprints** for initializing a new project from this template.
+Each profile decides, declaratively:
+
+- which crates under `crates/` are kept (everything not listed is removed),
+- which non-crate paths are removed (`benchmarks`, `fuzz`, `.template`, `docs/patterns`),
+- which `.github/workflows/*` files are removed,
+- the **default CI verification tier** written into `config/xtask.json`,
+- the **post-init checklist** printed for items that cannot travel through a GitHub template.
+
+Profiles live in `config/template-profiles/*.toml` and are structurally validated against
+`schema/template-profile.schema.json` before use.
+
+## Selection table
+
+| Profile | Best for | Keeps | CI default tier |
+|---|---|---|---|
+| `minimal` | Small app | `sample-app` + renamed lib + `xtask` + tests | `pull-request` |
+| `library` | Reusable library | renamed lib + `xtask` + tests | `protected-branch` |
+| `cli` | Binary tool | `sample-app` + renamed lib + `xtask` + tests | `protected-branch` |
+| `service` | Long-running service | actor/storage/registry patterns + `xtask` | `protected-branch` |
+| `workspace` | Full reference | every crate, benchmark, and workflow | `protected-branch` |
+| `ai-agent` | Agent-centric dev | `sample-app` + lib + `xtask` + agent tooling | `pull-request` |
+
+## Commands
+
+```bash
+# Initialize with a profile (rename + shape + CI tier + checklist)
+./scripts/init-template.sh --profile library --name my-lib
+cargo run -p xtask --bin xtask -- template init --profile service --name my-service
+
+# Validate a blueprint (by id or by path) against the schema
+cargo run -p xtask --bin xtask -- template validate-profile --profile config/template-profiles/library.toml
+
+# Inspect a profile's plan
+cargo run -p xtask --bin xtask -- template inspect --profile minimal
+
+# Dry-run without modifying anything
+./scripts/init-template.sh --profile minimal --name my-app --dry-run
+```
+
+`./scripts/init-template.sh --minimal` is a **backwards-compatible shorthand** for
+`--profile minimal` (it delegates to xtask; behavior is otherwise identical).
+
+## File ownership
+
+| Kind | Files |
+|---|---|
+| **Template-owned** | `config/template-profiles/*.toml`, `schema/template-profile.schema.json`, `crates/xtask/src/template_profile.rs`, `scripts/init-template.sh` |
+| **Downstream-owned** (adjust after init) | `config/xtask.json` (CI tiers), `Cargo.toml` metadata, `VERSION`, release/changelog policy |
+
+`VERSION` is always the downstream project's version source of truth;
+`.template/CHANGELOG-TEMPLATE.md` stays template-internal only.

--- a/schema/ci-telemetry.schema.json
+++ b/schema/ci-telemetry.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/d-oit/rust-2026-template/schema/ci-telemetry.schema.json",
+  "title": "CI Telemetry Artifact (quality-run.json)",
+  "description": "Structured telemetry emitted by `xtask quality run` after each CI run. schema_version must match crates/xtask/src/telemetry.rs::SCHEMA_VERSION.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "timestamp",
+    "tier",
+    "plan_source",
+    "scope",
+    "stages",
+    "toolchain"
+  ],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "timestamp": { "type": "string", "format": "date-time" },
+    "tier": { "type": "string", "minLength": 1 },
+    "plan_source": { "type": "string", "minLength": 1 },
+    "scope": {
+      "type": "object",
+      "required": ["mode", "packages", "fallback_used"],
+      "properties": {
+        "mode": { "enum": ["all", "affected-packages"] },
+        "packages": { "type": "array", "items": { "type": "string" } },
+        "fallback_used": { "type": "boolean" }
+      }
+    },
+    "stages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "status", "duration_ms", "cache"],
+        "properties": {
+          "id": { "type": "string" },
+          "status": { "enum": ["passed", "failed", "skipped"] },
+          "duration_ms": { "type": "integer", "minimum": 0 },
+          "cache": { "enum": ["restored", "saved", "miss", "not-applicable"] },
+          "skipped_reason": { "type": "string" }
+        }
+      }
+    },
+    "toolchain": {
+      "type": "object",
+      "required": ["rustc", "cargo", "nextest"],
+      "properties": {
+        "rustc": { "type": "string" },
+        "cargo": { "type": "string" },
+        "nextest": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schema/template-profile.schema.json
+++ b/schema/template-profile.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/d-oit/rust-2026-template/schema/template-profile.schema.json",
+  "title": "Template Profile (config/template-profiles/*.toml)",
+  "description": "Validated blueprint for `cargo xtask template init --profile <name>`. TOML files map to this object shape; structural validation is enforced by crates/xtask/src/template_profile.rs.",
+  "type": "object",
+  "required": ["metadata", "workspace", "ci", "post_init"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": ["id", "display_name", "description"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "display_name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" }
+      }
+    },
+    "workspace": {
+      "type": "object",
+      "required": ["include_crates"],
+      "properties": {
+        "include_crates": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "pattern": "^crates/[a-z0-9-]+$" }
+        },
+        "exclude_paths": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "exclude_workflows": {
+          "type": "array",
+          "items": { "type": "string", "pattern": ".yml$" }
+        }
+      }
+    },
+    "ci": {
+      "type": "object",
+      "required": ["default_tier"],
+      "properties": {
+        "default_tier": { "type": "string", "minLength": 1 }
+      }
+    },
+    "post_init": {
+      "type": "object",
+      "required": ["checklist"],
+      "properties": {
+        "checklist": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}

--- a/scripts/init-template.sh
+++ b/scripts/init-template.sh
@@ -1,453 +1,79 @@
 #!/usr/bin/env bash
-# init-template.sh - Initialize a new project from the rust-2026-template.
-# Prompts for project details and rewrites all placeholder references.
-# Run after: git clone https://github.com/d-oit/rust-2026-template.git YOUR_REPO
+# init-template.sh - Thin compatibility wrapper around `cargo xtask template init`.
+#
+# All blueprint/profile logic lives in crates/xtask (issue #286): the six shipped
+# profiles (minimal, library, cli, service, workspace, ai-agent) are validated TOML
+# blueprints under config/template-profiles/. This script preserves the documented
+# interactive entrypoint and maps the legacy `--minimal` flag to `--profile minimal`.
+
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-# --- colors ---
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log()   { printf "${CYAN}==> %s${NC}\n" "$*"; }
-ok()    { printf "${GREEN}  ✓ %s${NC}\n" "$*"; }
-warn()  { printf "${YELLOW}  ! %s${NC}\n" "$*"; }
-fail()  { printf "${RED}  ✗ %s${NC}\n" "$*" >&2; exit 1; }
-
 DRY_RUN=0
-MINIMAL=0
+PROFILE="workspace"   # default: keep the full reference workspace (old `full` behaviour)
+PROJECT_NAME=""
+PROJECT_DESC=""
+AUTHOR=""
+REPO=""
 
 usage() {
-  cat <<EOF
+  cat <<'EOF'
 Usage: $(basename "$0") [OPTIONS]
 
-Initialize a new project from the rust-2026-template.
+Initialize a new project from the rust-2026-template (delegates to
+`cargo run -p xtask --bin xtask -- template init --profile <id> ...`).
+
+Profiles (config/template-profiles/): minimal | library | cli | service | workspace | ai-agent
 
 Options:
+  --profile PROFILE     Blueprint to apply (default: workspace)
+  --minimal             Shorthand for --profile minimal (kept for backwards compatibility)
   --dry-run             Preview changes without applying them
-  --minimal             Slim workspace for typical apps: keep sample-app + your
-                        renamed lib crate + xtask; remove optional pattern crates
-                        and optional workflows (DORA, mutants, eval, docs deploy…)
   --name NAME           Project/crate name (e.g., "my-app")
   --description DESC    Project description
   --author AUTHOR       Author name (e.g., "Jane Doe")
   --repo REPO           GitHub repo (e.g., "myorg/my-app")
   -h, --help            Show this help message
-
-If options are not provided, the script will prompt interactively.
-
-Recommended for most new codebases:
-  $(basename "$0") --minimal --name my-app --description "..." --author "..." --repo org/my-app
 EOF
   exit 0
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run)   DRY_RUN=1; shift ;;
-    --minimal)   MINIMAL=1; shift ;;
-    --name)      PROJECT_NAME="$2"; shift 2 ;;
-    --description) PROJECT_DESC="$2"; shift 2 ;;
-    --author)    AUTHOR="$2"; shift 2 ;;
-    --repo)      REPO="$2"; shift 2 ;;
-    -h|--help)   usage ;;
-    *)           fail "Unknown option: $1" ;;
+    --dry-run)    DRY_RUN=1; shift ;;
+    --minimal)    PROFILE="minimal"; shift ;;
+    --profile)    PROFILE="${2:?--profile requires a value}"; shift 2 ;;
+    --name)       PROJECT_NAME="${2:?--name requires a value}"; shift 2 ;;
+    --description) PROJECT_DESC="${2:?--description requires a value}"; shift 2 ;;
+    --author)     AUTHOR="${2:?--author requires a value}"; shift 2 ;;
+    --repo)       REPO="${2:?--repo requires a value}"; shift 2 ;;
+    -h|--help)    usage ;;
+    *)            echo "Unknown option: $1" >&2; usage ;;
   esac
 done
 
-# --- interactive prompts ---
-if [[ -z "${PROJECT_NAME:-}" ]]; then
-  printf "${CYAN}Project name (e.g., my-app):${NC} "
-  read -r PROJECT_NAME
-fi
-[[ -z "$PROJECT_NAME" ]] && fail "Project name is required"
-
-if [[ -z "${PROJECT_DESC:-}" ]]; then
-  printf "${CYAN}Description:${NC} "
-  read -r PROJECT_DESC
-fi
-[[ -z "$PROJECT_DESC" ]] && fail "Description is required"
-
-if [[ -z "${AUTHOR:-}" ]]; then
-  printf "${CYAN}Author name:${NC} "
-  read -r AUTHOR
-fi
-[[ -z "$AUTHOR" ]] && fail "Author is required"
-
-if [[ -z "${REPO:-}" ]]; then
-  printf "${CYAN}GitHub repo (org/name):${NC} "
-  read -r REPO
-fi
-[[ -z "$REPO" ]] && fail "GitHub repo is required"
-
-REPO_URL="https://github.com/${REPO}"
-
-log "Initializing project: $PROJECT_NAME"
-log "  Description: $PROJECT_DESC"
-log "  Author: $AUTHOR"
-log "  Repo: $REPO_URL"
-if [[ $MINIMAL -eq 1 ]]; then
-  log "  Profile: minimal (typical app workspace)"
-else
-  log "  Profile: full (keeps pattern crates and optional workflows)"
-fi
-echo ""
-
-# --- sed helper (GNU/BSD compatible) ---
-sedi() {
-  if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "$@"
-  else
-    sed -i "$@"
+# Interactive prompts (preserved from the legacy script).
+prompt() { # var label
+  local var="$1"
+  if [[ -z "${!var:-}" ]]; then
+    printf "%s: " "$2"
+    read -r val
+    printf -v "$var" '%s' "$val"
   fi
 }
+prompt PROJECT_NAME "Project name (e.g., my-app)"
+[[ -n "$PROJECT_NAME" ]] || { echo "Project name is required" >&2; exit 1; }
+prompt PROJECT_DESC "Description"
+prompt AUTHOR "Author name"
+prompt REPO "GitHub repo (org/name)"
 
-# --- replace in file ---
-replace_in_file() {
-  local file="$1"
-  local pattern="$2"
-  local replacement="$3"
-  if [[ $DRY_RUN -eq 1 ]]; then
-    ok "(dry run) Would update $file"
-  elif [[ -f "$file" ]]; then
-    sedi "s|$pattern|$replacement|g" "$file"
-    ok "Updated $file"
-  fi
-}
+ARGS=(--profile "$PROFILE" --name "$PROJECT_NAME")
+[[ -n "$PROJECT_DESC" ]] && ARGS+=(--description "$PROJECT_DESC")
+[[ -n "$AUTHOR" ]] && ARGS+=(--author "$AUTHOR")
+[[ -n "$REPO" ]] && ARGS+=(--repo "$REPO")
+[[ $DRY_RUN -eq 1 ]] && ARGS+=(--dry-run)
 
-# --- replace literal string in file (escapes [ ] for sed) ---
-replace_literal() {
-  local file="$1"
-  local literal="$2"
-  local replacement="$3"
-  if [[ $DRY_RUN -eq 1 ]]; then
-    ok "(dry run) Would update $file"
-  elif [[ -f "$file" ]]; then
-    local escaped
-    escaped=$(printf '%s' "$literal" | sed 's/[][]/\\&/g')
-    sedi "s|$escaped|$replacement|g" "$file"
-    ok "Updated $file"
-  fi
-}
-
-# --- remove path (dry-run aware) ---
-remove_path() {
-  local path="$1"
-  if [[ $DRY_RUN -eq 1 ]]; then
-    ok "(dry run) Would remove $path"
-  elif [[ -e "$path" ]]; then
-    rm -rf "$path"
-    ok "Removed $path"
-  fi
-}
-
-# --- minimal profile: drop optional pattern crates + optional workflows ---
-# Keeps: crates/sample-app, crates/example-crate (renamed), crates/xtask,
-# core CI (ci, commitlint, release*, security/secretlint, hotfix, dependabot).
-if [[ $MINIMAL -eq 1 ]]; then
-  log "Applying --minimal profile"
-
-  for crate in \
-    actor-runtime-template \
-    checkpoint-template \
-    hybrid-storage-template \
-    mcp-server-template \
-    example-registry-pattern \
-    example-storage-pattern
-  do
-    remove_path "crates/$crate"
-  done
-
-  for wf in \
-    dora-fdrt.yml \
-    dora-report.yml \
-    eval.yml \
-    mutants.yml \
-    skills-evaluation.yml \
-    update-architecture-diagram.yml \
-    cleanup-ci-status.yml \
-    sync-labels.yml \
-    labeler.yml \
-    patch-release-on-label.yml \
-    deploy-docs.yml \
-    fuzz.yml
-  do
-    remove_path ".github/workflows/$wf"
-  done
-
-  # Optional meta-template surface (safe for adopters to drop)
-  remove_path "fuzz"
-  remove_path "benchmarks"
-  remove_path "docs/patterns"
-  remove_path ".template"
-
-  # Workspace members use crates/* examples/* benchmarks — drop benchmarks member if dir gone
-  # Cargo.toml members = ["crates/*", "examples/*", "benchmarks"] — fix when benchmarks removed
-  if [[ $DRY_RUN -eq 0 ]] && [[ ! -d benchmarks ]]; then
-    if grep -q '"benchmarks"' Cargo.toml 2>/dev/null; then
-      sedi 's/, "benchmarks"//' Cargo.toml
-      sedi 's/"benchmarks", //' Cargo.toml
-      ok "Removed benchmarks from workspace members"
-    fi
-  fi
-fi
-
-# --- rename example-crate ---
-CrateName=$(echo "$PROJECT_NAME" | tr '-' '_')
-log "Renaming crates/example-crate -> crates/$PROJECT_NAME"
-
-if [[ $DRY_RUN -eq 1 ]]; then
-  ok "(dry run) Would rename crates/example-crate -> crates/$PROJECT_NAME"
-else
-  if [[ -d "crates/$PROJECT_NAME" ]]; then
-    warn "crates/$PROJECT_NAME already exists, skipping rename"
-  else
-    mv "crates/example-crate" "crates/$PROJECT_NAME"
-    ok "Renamed crates/example-crate -> crates/$PROJECT_NAME"
-  fi
-fi
-
-# --- rewrite Cargo.toml (workspace) ---
-log "Updating Cargo.toml"
-# Strip root [package], [dependencies], [dev-dependencies], [lints] —
-# the workspace root must be a virtual manifest (no own crate).
-for section in package dependencies dev-dependencies lints; do
-  sedi "/^\[$section\]/,/^\[/{ /^\[$section\]/d; /^\[/!d; }" Cargo.toml
-done
-replace_in_file "Cargo.toml" 'description = "A production-ready Rust workspace template.*"' "description = \"$PROJECT_DESC\""
-replace_in_file "Cargo.toml" 'authors = \["Your Name"\]' "authors = [\"$AUTHOR\"]"
-replace_in_file "Cargo.toml" 'repository = "https://github.com/your-org/your-repo"' "repository = \"$REPO_URL\""
-replace_in_file "Cargo.toml" 'homepage = "https://github.com/your-org/your-repo"' "homepage = \"$REPO_URL\""
-replace_in_file "Cargo.toml" 'documentation = "https://docs.rs/your-crate"' "documentation = \"https://docs.rs/$PROJECT_NAME\""
-
-# --- rewrite crate Cargo.toml ---
-CRATE_TOML="crates/$PROJECT_NAME/Cargo.toml"
-log "Updating $CRATE_TOML"
-replace_in_file "$CRATE_TOML" 'name = "example-crate"' "name = \"$PROJECT_NAME\""
-replace_in_file "$CRATE_TOML" 'description = "Example crate in the rust-2026-template workspace"' "description = \"$PROJECT_DESC\""
-
-# --- rewrite sample-app Cargo.toml ---
-log "Updating crates/sample-app/Cargo.toml"
-replace_in_file "crates/sample-app/Cargo.toml" 'description = "Sample application demonstrating the rust-2026-template"' "description = \"Sample application for $PROJECT_NAME\""
-
-# --- rewrite template crate Cargo.toml files (skipped if --minimal removed them) ---
-for crate in actor-runtime-template checkpoint-template hybrid-storage-template mcp-server-template; do
-  TOML="crates/$crate/Cargo.toml"
-  if [[ -f "$TOML" ]]; then
-    log "Updating $TOML"
-    replace_in_file "$TOML" "Hand-rolled actor runtime template: mailbox, state, and supervision patterns" "$PROJECT_DESC"
-    replace_in_file "$TOML" "Checkpoint template for serializable application state with migration support" "$PROJECT_DESC"
-    replace_in_file "$TOML" "Hybrid storage template with SQL + KV backends and caching" "$PROJECT_DESC"
-    replace_in_file "$TOML" "MCP server template crate with tool registration and dispatch" "$PROJECT_DESC"
-  fi
-done
-
-# --- rewrite AGENTS.md ---
-log "Updating AGENTS.md"
-replace_in_file "AGENTS.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite CLAUDE.md ---
-log "Updating CLAUDE.md"
-replace_in_file "CLAUDE.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite GEMINI.md ---
-log "Updating GEMINI.md"
-replace_in_file "GEMINI.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite QWEN.md ---
-log "Updating QWEN.md"
-replace_in_file "QWEN.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite README.md ---
-log "Updating README.md"
-# Specific badge-URL rewrites must run BEFORE the generic `rust-2026-template`
-# substitution below, otherwise the generic replace would mangle the badge URLs.
-# NOTE: no version-badge rewrite here by design — the template's README no longer
-# carries a version badge; the template's version is tracked exclusively in
-# `.template/CHANGELOG-TEMPLATE.md` (see scripts/bump-template-version.sh).
-replace_in_file "README.md" '# Rust 2026 Template' "# $PROJECT_NAME"
-replace_in_file "README.md" 'https://github.com/d-oit/rust-2026-template' "$REPO_URL"
-replace_in_file "README.md" 'https://codecov.io/gh/d-oit/rust-2026-template' "https://codecov.io/gh/${REPO}"
-replace_in_file "README.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite CONTRIBUTING.md ---
-log "Updating CONTRIBUTING.md"
-replace_in_file "CONTRIBUTING.md" '# Contributing to rust-2026-template' "# Contributing to $PROJECT_NAME"
-replace_in_file "CONTRIBUTING.md" 'https://github.com/d-oit/rust-2026-template' "$REPO_URL"
-
-# --- rewrite SECURITY.md ---
-log "Updating SECURITY.md"
-replace_in_file "SECURITY.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite QUICKSTART.md ---
-log "Updating QUICKSTART.md"
-replace_in_file "QUICKSTART.md" '# Quick Start — rust-2026-template' "# Quick Start — $PROJECT_NAME"
-replace_in_file "QUICKSTART.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite MIGRATION.md ---
-log "Updating MIGRATION.md"
-replace_in_file "MIGRATION.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite flake.nix ---
-log "Updating flake.nix"
-replace_in_file "flake.nix" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite release.toml ---
-log "Updating release.toml"
-replace_in_file "release.toml" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite scripts/bump-version.sh ---
-log "Updating scripts/bump-version.sh"
-replace_in_file "scripts/bump-version.sh" 'your-org/your-repo' "$REPO"
-
-# --- rewrite CHANGELOG.md link footer ---
-log "Updating CHANGELOG.md"
-replace_in_file "CHANGELOG.md" 'your-org/your-repo' "$REPO"
-
-# --- rewrite llms.txt header ---
-log "Updating llms.txt"
-replace_in_file "llms.txt" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite roast-scorer.sh ---
-log "Updating scripts/roast-scorer.sh"
-replace_in_file "scripts/roast-scorer.sh" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite HARNESS.md ---
-log "Updating HARNESS.md"
-replace_in_file "HARNESS.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite scripts/bootstrap.sh ---
-log "Updating scripts/bootstrap.sh"
-replace_in_file "scripts/bootstrap.sh" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite scripts/generate-llms-txt.sh ---
-log "Updating scripts/generate-llms-txt.sh"
-replace_in_file "scripts/generate-llms-txt.sh" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite .clippy.toml ---
-log "Updating .clippy.toml"
-replace_in_file ".clippy.toml" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite docs/architecture/context.yaml ---
-log "Updating docs/architecture/context.yaml"
-replace_in_file "docs/architecture/context.yaml" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite agents-docs/structure.md ---
-log "Updating agents-docs/structure.md"
-replace_in_file "agents-docs/structure.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite crates/sample-app/README.md ---
-log "Updating crates/sample-app/README.md"
-replace_in_file "crates/sample-app/README.md" 'rust-2026-template' "$PROJECT_NAME"
-
-# --- rewrite fuzz/Cargo.toml (may be removed under --minimal) ---
-if [[ -f "fuzz/Cargo.toml" ]]; then
-  log "Updating fuzz/Cargo.toml"
-  replace_in_file "fuzz/Cargo.toml" 'rust-2026-template' "$PROJECT_NAME"
-  replace_literal "fuzz/Cargo.toml" \
-    'example-crate = { path = "../crates/example-crate"' \
-    "$PROJECT_NAME = { path = \"../crates/$PROJECT_NAME\""
-  replace_literal "fuzz/Cargo.toml" 'ignored = ["example-crate"]' "ignored = [\"$PROJECT_NAME\"]"
-fi
-
-# --- rewrite benchmarks/Cargo.toml (may be removed under --minimal) ---
-if [[ -f "benchmarks/Cargo.toml" ]]; then
-  log "Updating benchmarks/Cargo.toml"
-  sedi '/rust-2026-template = { path = "\.\." }/d' benchmarks/Cargo.toml
-  replace_literal "benchmarks/Cargo.toml" \
-    'example-crate = { path = "../crates/example-crate"' \
-    "$PROJECT_NAME = { path = \"../crates/$PROJECT_NAME\""
-fi
-
-# --- rewrite CI workflows with repo-specific checks (files may be gone under --minimal) ---
-log "Updating CI workflow repo checks"
-replace_in_file ".github/workflows/dora-fdrt.yml" 'd-oit/rust-2026-template' "$REPO"
-replace_in_file ".github/workflows/dora-report.yml" 'd-oit/rust-2026-template' "$REPO"
-replace_in_file ".github/workflows/sync-labels.yml" 'd-oit/rust-2026-template' "$REPO"
-
-# --- rewrite label scripts ---
-log "Updating label management scripts"
-replace_in_file "scripts/learn-labels.sh" 'd-oit/rust-2026-template' "$REPO"
-replace_in_file "scripts/setup-github-labels.sh" 'd-oit/rust-2026-template' "$REPO"
-
-# --- rewrite skill author metadata ---
-log "Updating skill author metadata"
-for skill_md in .agents/skills/*/SKILL.md; do
-  if grep -q 'author: d-oit' "$skill_md" 2>/dev/null; then
-    replace_in_file "$skill_md" 'author: d-oit' "author: $AUTHOR"
-  fi
-done
-
-# --- rewrite example crate README ---
-EXAMPLE_README="crates/$PROJECT_NAME/README.md"
-if [[ -f "$EXAMPLE_README" ]]; then
-  log "Updating $EXAMPLE_README"
-  replace_in_file "$EXAMPLE_README" '# example-crate' "# $PROJECT_NAME"
-  replace_in_file "$EXAMPLE_README" 'example-crate' "$PROJECT_NAME"
-fi
-
-# --- rewrite example crate lib.rs ---
-EXAMPLE_LIB="crates/$PROJECT_NAME/src/lib.rs"
-if [[ -f "$EXAMPLE_LIB" ]]; then
-  log "Updating $EXAMPLE_LIB"
-  replace_in_file "$EXAMPLE_LIB" '# example-crate' "# $PROJECT_NAME"
-  replace_in_file "$EXAMPLE_LIB" 'example-crate' "$PROJECT_NAME"
-  replace_in_file "$EXAMPLE_LIB" 'example_crate' "$CrateName"
-fi
-
-# --- rewrite examples ---
-EXAMPLES_DIR="examples/hello_world"
-if [[ -f "$EXAMPLES_DIR/src/main.rs" ]]; then
-  log "Updating examples/hello_world/src/main.rs"
-  replace_in_file "$EXAMPLES_DIR/src/main.rs" 'example_crate' "$CrateName"
-  replace_in_file "$EXAMPLES_DIR/src/main.rs" 'example-crate' "$PROJECT_NAME"
-fi
-
-EXAMPLES_TOML="examples/hello_world/Cargo.toml"
-if [[ -f "$EXAMPLES_TOML" ]]; then
-  log "Updating $EXAMPLES_TOML"
-  replace_literal "$EXAMPLES_TOML" \
-    'example-crate = { path = "../../crates/example-crate"' \
-    "$PROJECT_NAME = { path = \"../../crates/$PROJECT_NAME\""
-fi
-
-# --- validate ---
-log "Validating build"
-if [[ $DRY_RUN -eq 1 ]]; then
-  echo ""
-  ok "Dry run complete. No changes were applied."
-  echo ""
-  log "Next steps:"
-  echo "  1. Run: $(basename "$0")"
-  echo "  2. Verify: cargo build --workspace"
-  echo "  3. Commit: git add -A && git commit -m 'feat: initialize from rust-2026-template'"
-  exit 0
-fi
-
-echo ""
-log "Verifying the build compiles..."
-if command -v cargo >/dev/null 2>&1; then
-  if cargo check --workspace 2>/dev/null; then
-    ok "Build check passed"
-  else
-    warn "Build check had issues - review output above"
-  fi
-else
-  warn "cargo not found - skipping build verification"
-fi
-
-echo ""
-ok "Template initialized successfully!"
-echo ""
-log "Next steps:"
-echo "  1. Review changes: git diff"
-echo "  2. Build: cargo build --workspace"
-echo "  3. Test: cargo nextest run --workspace"
-echo "  4. Quality gate: ./scripts/quality-gates.sh"
-echo "  5. Commit: git add -A && git commit -m 'feat: initialize from rust-2026-template'"
-echo "  6. Push: git push origin main"
+echo "==> Delegating to: cargo run -p xtask --bin xtask -- template init ${ARGS[*]}"
+exec cargo run -p xtask --bin xtask -- template init "${ARGS[@]}"


### PR DESCRIPTION
Implements **#286** (project profiles as validated blueprints) and **#289** (CI telemetry contract).

## #286 — Project Profiles
- Six validated blueprints in `config/template-profiles/`: `minimal`, `library`, `cli`, `service`, `workspace`, `ai-agent` (JSON Schema: `schema/template-profile.schema.json`).
- `crates/xtask/src/template_profile.rs`: typed, `deny_unknown_fields`-validated loader; plans crate/path/workflow removals; `inspect`.
- `template init --profile <id>` now shapes the workspace (keep/drop crates, paths, workflows), renames `example-crate`, rewrites all placeholder refs (incl. examples/benchmarks + tool-adapter docs), writes the profile's CI-tier default into `config/xtask.json`, and prints the post-init checklist.
- Subcommands: `template init`, `template validate-profile`, `template inspect`.
- `scripts/init-template.sh` is now a **thin compatibility wrapper** (453 → 60 lines) delegating to xtask; `--minimal` → `--profile minimal`.
- Docs: `docs/template-profiles.md`, README selection table, QUICKSTART.

## #289 — CI telemetry
- `config/ci/telemetry.toml` + `schema/ci-telemetry.schema.json` (budgets are config, not application logic).
- `crates/xtask/src/telemetry.rs`: emits `.agents/ci/quality-run.json` (schema v1: tier, plan source, scope with affected-package detection + fallback, per-stage timing/skip reasons, toolchain versions) and `.agents/ci/quality-summary.md`.
- `quality run` appends the telemetry summary to the GHA step summary; the CI `quality-gate` job uploads `quality-run.json` as the `ci-telemetry` artifact (always-run, even on failure).
- Telemetry artifacts are gitignored (uploaded, not committed); docs in `docs/ci-observability.md` + `.agents/ci/README.md`.

## Verification
- 36/36 xtask tests (profile validation/planning, telemetry serialization/emit, boundary). clippy `-D warnings` clean.
- End-to-end: `init --profile minimal` on a fresh copy → buildable workspace (`cargo check --workspace` green), correct crate pruning, no stale `example-crate` refs, CI tier written, checklist printed.
- yamllint + markdownlint clean.