### PR TITLE
fix(ci): fix keyword count calculation and summary output in learn-labels.sh

### DIFF
--- a/.agents/ci/ci-status.json
+++ b/.agents/ci/ci-status.json
@@ -1,21 +1,88 @@
 {
-  "timestamp": "2026-08-21T19:57:33Z",
-  "commit": "0e22190b3a213d31b3108e62b4b65aaf8c46bee9",
-  "branch": "main",
-  "jobs": {
-    "validate-agents": "success",
-    "lint": "success",
-    "shellcheck": "success",
-    "gitleaks": "success",
-    "fmt": "success",
-    "clippy": "success",
-    "test": "success",
-    "security": "success",
-    "deny": "success",
-    "bench": "success",
-    "version-check": "success",
-  "msrv": "success",
-  "roast": "success"
-  },
+  "timestamp": "2026-08-21T20:26:21Z",
+  "commit": "08c3fd0a585786b592f07ba2ba0085620a5724fa",
+  "branch": "jules-15467531984231833385-c4171ef6",
+  "checks": [
+    {
+      "name": "LOC Limits",
+      "status": "success",
+      "message": "Passed in 12.786941ms"
+    },
+    {
+      "name": "Rust Format",
+      "status": "success",
+      "message": "Passed in 363.29571ms"
+    },
+    {
+      "name": "Rust Clippy",
+      "status": "success",
+      "message": "Passed in 162.330020024s"
+    },
+    {
+      "name": "Rust Build",
+      "status": "success",
+      "message": "Passed in 56.504202648s"
+    },
+    {
+      "name": "Rust Tests",
+      "status": "success",
+      "message": "Passed in 36.359579073s"
+    },
+    {
+      "name": "Rust Doc Tests",
+      "status": "success",
+      "message": "Passed in 24.557193546s"
+    },
+    {
+      "name": "Rust Security Audit",
+      "status": "success",
+      "message": "Passed in 111.916147ms"
+    },
+    {
+      "name": "Rust Dependency Policy (Deny)",
+      "status": "success",
+      "message": "Passed in 116.691218ms"
+    },
+    {
+      "name": "Rust Unused Dependencies (Machete)",
+      "status": "success",
+      "message": "Passed in 15.313721ms"
+    },
+    {
+      "name": "Rust MSRV Audit",
+      "status": "success",
+      "message": "Passed in 26.024796765s"
+    },
+    {
+      "name": "Shell Script Lint (ShellCheck)",
+      "status": "success",
+      "message": "Passed in 18.361129ms"
+    },
+    {
+      "name": "Markdown Lint (markdownlint-cli2)",
+      "status": "success",
+      "message": "Passed in 15.412911ms"
+    },
+    {
+      "name": "Privacy Check (No emails)",
+      "status": "success",
+      "message": "Passed in 63.548236ms"
+    },
+    {
+      "name": "Secret Scan",
+      "status": "success",
+      "message": "Passed in 72.538628ms"
+    },
+    {
+      "name": "GitHub Actions Workflow Validation",
+      "status": "success",
+      "message": "Passed in 8.756328001s"
+    },
+    {
+      "name": "CI Status Artifact Check",
+      "status": "success",
+      "message": "Passed in 134.363µs"
+    }
+  ],
   "overall": "success"
 }

--- a/.agents/ci/ci-summary.md
+++ b/.agents/ci/ci-summary.md
@@ -1,21 +1,26 @@
-# CI Status Summary
+# Quality Gate Run Summary
 
-**Last updated:** 2026-08-21T19:57:33Z
-**Commit:** 0e22190b3a213d31b3108e62b4b65aaf8c46bee9
-**Branch:** main
+**Timestamp:** 2026-08-21T20:26:21Z
+**Commit:** 08c3fd0a585786b592f07ba2ba0085620a5724fa
+**Branch:** jules-15467531984231833385-c4171ef6
 
-## Job Results
+| Check | Status | Details |
+|---|---|---|
+| LOC Limits | ✅ success | Passed in 12.786941ms |
+| Rust Format | ✅ success | Passed in 363.29571ms |
+| Rust Clippy | ✅ success | Passed in 162.330020024s |
+| Rust Build | ✅ success | Passed in 56.504202648s |
+| Rust Tests | ✅ success | Passed in 36.359579073s |
+| Rust Doc Tests | ✅ success | Passed in 24.557193546s |
+| Rust Security Audit | ✅ success | Passed in 111.916147ms |
+| Rust Dependency Policy (Deny) | ✅ success | Passed in 116.691218ms |
+| Rust Unused Dependencies (Machete) | ✅ success | Passed in 15.313721ms |
+| Rust MSRV Audit | ✅ success | Passed in 26.024796765s |
+| Shell Script Lint (ShellCheck) | ✅ success | Passed in 18.361129ms |
+| Markdown Lint (markdownlint-cli2) | ✅ success | Passed in 15.412911ms |
+| Privacy Check (No emails) | ✅ success | Passed in 63.548236ms |
+| Secret Scan | ✅ success | Passed in 72.538628ms |
+| GitHub Actions Workflow Validation | ✅ success | Passed in 8.756328001s |
+| CI Status Artifact Check | ✅ success | Passed in 134.363µs |
 
-| Job | Status |
-|---|---|
-| lint | ✅ success |
-| test | ✅ success |
-| security | ✅ success |
-| bench | ✅ success |
-| roast | ✅ success |
-
-## Known Issues
-- None
-
-## Flaky Tests
-- None detected in last 10 runs
+### Overall: **SUCCESS**

--- a/scripts/learn-labels.sh
+++ b/scripts/learn-labels.sh
@@ -225,7 +225,7 @@ KEYWORD_MAP=(
 declare -A KW_COUNT
 for entry in "${KEYWORD_MAP[@]}"; do
   kw=$(echo "$entry" | cut -d'|' -f1)
-  count=$(echo "$ALL_TEXT" | grep -ciE "\b${kw}\b" 2>/dev/null || echo 0)
+  count=$(echo "$ALL_TEXT" | grep -ciE "\b${kw}\b" || true)
   KW_COUNT["$kw"]=$count
 done
 


### PR DESCRIPTION
Fixes the bug where `scripts/learn-labels.sh` exited prematurely due to multi-line count outputs from `grep -ciE ... || echo 0` under `pipefail`. Using `|| true` ensures clean integer counts and allows the script to complete and output `SUMMARY:`, fixing the workflow summary reporting.

Fixes #311

---
*PR created automatically by Jules for task [15467531984231833385](https://jules.google.com/task/15467531984231833385) started by @d-oit*